### PR TITLE
increase coarse delay cell bitwidth from 4 to 5

### DIFF
--- a/md/mdll_r1_top_intf.md
+++ b/md/mdll_r1_top_intf.md
@@ -16,7 +16,7 @@
 | jm_bb_out_pol_jtag       |           |            |               | Test         | out      | 1         |
 | fb_ndiv_jtag             |           | 3:0        |               | Test         | out      | 'h5       |
 | dco_ctl_offset_jtag      |           | 1:0        |               | Test         | out      | 'h0       |
-| dco_ctl_track_lv_jtag    |           | 8:0        |               | Test         | out      | 'h1       |
+| dco_ctl_track_lv_jtag    |           | 9:0        |               | Test         | out      | 'h1       |
 | dac_ctl_track_lv_jtag    |           | 5:0        |               | Test         | out      | 'hf       |
 | gain_bb_jtag             |           | 3:0        |               | Test         | out      | 'h8       |
 | gain_bb_dac_jtag         |           | 3:0        |               | Test         | out      | 'h1       |
@@ -27,6 +27,6 @@
 | jm_sel_clk_jtag          |           | 2:0        |               | Test         | out      | 'h0       |
 | fcal_ready_2jtag         |           |            |               | System       | in       |           |
 | fcal_cnt_2jtag           |           | 9:0        |               | System       | in       |           |
-| dco_ctl_fine_mon_2jtag   |           | 8:0        |               | System       | in       |           |
+| dco_ctl_fine_mon_2jtag   |           | 9:0        |               | System       | in       |           |
 | dac_ctl_mon_2jtag        |           | 5:0        |               | System       | in       |           |
 | jm_cdf_out_2jtag         |           | 24:0       |               | System       | in       |           |

--- a/vlog/new_chip_src/mdll_r1/rtl/mdll_pkg.sv
+++ b/vlog/new_chip_src/mdll_r1/rtl/mdll_pkg.sv
@@ -56,7 +56,7 @@ package mdll_pkg;
 	// coarse delay; set by FCAL
     //parameter int N_DCO_C = 4; // bit width of coarse control
 	// tracking delay
-	parameter int N_DCO_TI_MSB = 4;	// bit width of tracking control word (MSB)
+	parameter int N_DCO_TI_MSB = 5;	// bit width of tracking control word (MSB)
 	parameter int N_DCO_TI_LSB = 5;	// bit width of tracking control word (LSB)
 	parameter int N_PI = N_DCO_TI_LSB;// bit width of PI control
     parameter int N_DCO_TI = (N_DCO_TI_MSB+N_PI); 	// bit width of tracking control (integer)


### PR DESCRIPTION
As the number of delay cell is changed from 2 to 1, it needs to increase the adjustable delay range of the delay cell unit.