### PR TITLE
Add BIST for PRBS checker

### DIFF
--- a/md/dcore_intf.md
+++ b/md/dcore_intf.md
@@ -32,7 +32,8 @@
 | int_rstb                   |         |                        |                  | Test         | out      |   0       |
 | sram_rstb                  |         |                        |                  | Test         | out      |   1       |
 | cdr_rstb                   |         |                        |                  | Test         | out      |   1       |
-| prbs_rstb                  |         |                        |                  | Test         | out      |   1       |
+| prbs_rstb                  |         |                        |                  | Test         | out      |   0       |
+| prbs_gen_rstb              |         |                        |                  | Test         | out      |   0       |
 | sel_outbuff				 | 		   | 3:0					|				   | Test		  | out 	 |   0		 |
 | sel_trigbuff				 | 		   | 3:0					|				   | Test		  | out 	 |   0		 |
 | en_outbuff				 | 		   |     					|				   | Test		  | out 	 |   0		 |

--- a/md/prbs_intf.md
+++ b/md/prbs_intf.md
@@ -9,3 +9,9 @@
 | prbs_err_bits_lower        |         | 31:0            |                | System       | in       |                                              |
 | prbs_total_bits_upper      |         | 31:0            |                | System       | in       |                                              |
 | prbs_total_bits_lower      |         | 31:0            |                | System       | in       |                                              |
+| prbs_gen_cke               |         |                 |                | Test         | out      | 0                                            |
+| prbs_gen_init              |         | Nprbs-1:0       |                | Test         | out      | 'h00000001                                   |
+| prbs_gen_eqn               |         | Nprbs-1:0       |                | Test         | out      | 'b00000000000000000000000001100000           |
+| prbs_gen_inj_err           |         |                 |                | Test         | out      | 0                                            |
+| prbs_gen_chicken           |         | 1:0             |                | Test         | out      | 'b00                                         |
+

--- a/tests/new_tests/PRBS/test.sv
+++ b/tests/new_tests/PRBS/test.sv
@@ -4,10 +4,6 @@
 
 `define GET_PDBG(name) top_i.idcore.pdbg_intf_i.``name``
 
-`ifndef PRBS_DEL
-    `define PRBS_DEL 0
-`endif
-
 module test;
 	
 	import const_pack::*;
@@ -45,77 +41,6 @@ module test;
 		.ckoutb(ext_clkn)
 	);
 
-    // PRBS data generator
-
-    logic clk_full_rate;
-	clock #(
-		.freq(full_rate),
-		.duty(0.5),
-		.td(0)
-	) clock_full_rate_i (
-		.ckout(clk_full_rate),
-		.ckoutb()
-	);
-
-    logic clk_div_Nti;
-	clock #(
-		.freq(full_rate / Nti),
-		.duty(0.5),
-		.td(0)
-	) clock_div_Nti_i (
-		.ckout(clk_div_Nti),
-		.ckoutb()
-	);
-
-    logic prbs_out;
-    logic stim_rst;
-    prbs_generator #(
-        .n_prbs(7)
-    ) prbs_gen_i (
-        .clk(clk_full_rate),
-        .rst(stim_rst),
-        .cke(1'b1),
-        .init_val(1),
-        .out(prbs_out)
-    );
-
-    // store up a history of PRBS bits
-    logic [269:0] prbs_mem;
-    always @(posedge clk_full_rate) begin
-        if (stim_rst == 1'b1) begin
-            prbs_mem <= 0;
-        end else begin
-            prbs_mem <= {prbs_out, prbs_mem[269:1]};
-        end
-    end
-
-    // add current PRBS bit to the history
-    logic [270:0] prbs_concat;
-    assign prbs_concat = {prbs_out, prbs_mem};
-
-    // select a delayed slice of those PRBS bits
-    logic [(Nti-1):0] rx_bits_imm;
-    logic [(Nti-1):0] rx_bits;
-
-    assign rx_bits_imm = prbs_concat[(270-(`PRBS_DEL)) -: Nti];
-
-    always @(posedge clk_div_Nti) begin
-        if (stim_rst == 1'b1) begin
-            #(10ps);
-            force top_i.idcore.prbs_rx_bits = 0;
-        end else begin
-            #(10ps);
-            force top_i.idcore.prbs_rx_bits = rx_bits_imm;
-        end
-    end
-
-    // Stimulus reset
-    initial begin
-        stim_rst = 1'b1;
-        #(10ns);
-        stim_rst = 1'b0;
-    end
-
 	// Main test
 
 	logic [31:0] result;
@@ -152,12 +77,21 @@ module test;
         `FORCE_ADBG(en_v2t, 1);
         #(1ns);
 
-        // Toggle the PRBS block reset
-        $display("Reset the PRBS tester (case 1)");
-        `FORCE_DDBG(prbs_rstb, 0);
+        // Turn on the PRBS generator
+        $display("Turn on the PRBS generator (case 1)");
+        `FORCE_DDBG(prbs_gen_rstb, 1);
+        `FORCE_PDBG(prbs_gen_cke, 1);
+        #(50ns);
+
+        // Select the PRBS checker data source
+        $display("Select the PRBS checker data source (case 1)");
+        `FORCE_DDBG(sel_prbs_mux, 2'b11);
         #(10ns);
+
+        // Release the PRBS checker from reset
+        $display("Release the PRBS tester from reset (case 1)");
         `FORCE_DDBG(prbs_rstb, 1);
-        #(10ns);
+        #(50ns);
 
         // run the PRBS tester
         $display("Running the PRBS tester (case 1)");
@@ -178,16 +112,19 @@ module test;
         total_bits_1 <<= 32;
         total_bits_1 |= `GET_PDBG(prbs_total_bits_lower);
 
-        // Change the PRBS equation and reset the tester
+        // Reset the PRBS checker
         $display("Reset the PRBS tester (case 2)");
         `FORCE_PDBG(prbs_checker_mode, 0);
-        `FORCE_PDBG(prbs_eqn, 7'b1100001);
-        #(100ns);
+        #(50ns);
 
-        // run the PRBS tester
+        // run the PRBS tester, but inject an error in the middle
         $display("Running the PRBS tester (case 2)");
         `FORCE_PDBG(prbs_checker_mode, 2);
-        #(625ns);
+        #(300ns);
+        `FORCE_PDBG(prbs_gen_inj_err, 1);
+        #(25ns);
+        `FORCE_PDBG(prbs_gen_inj_err, 0);
+        #(300ns);
 
         // get results
         `FORCE_PDBG(prbs_checker_mode, 3);
@@ -204,7 +141,6 @@ module test;
         total_bits_2 |= `GET_PDBG(prbs_total_bits_lower);
 
         // print results
-        $display("n_delay: %0d", `PRBS_DEL);
         $display("err_bits_1: %0d", err_bits_1);
         $display("total_bits_1: %0d", total_bits_1);
         $display("err_bits_2: %0d", err_bits_2);
@@ -230,10 +166,10 @@ module test;
             $display("Number of bits transmitted is OK (case 2)");
         end
 
-        if (!(err_bits_2 > 0)) begin
-            $error("Bit errors should be detected (case 2)");
+        if (!(err_bits_2 == 48)) begin
+            $error("3*16=48 bit errors should be detected (case 2)");
         end else begin
-            $display("Bit errors detected, as expected for case 2");
+            $display("3*16=48 bit errors detected, as expected for case 2");
         end
 
 		// Finish test

--- a/tests/test_prbs_generator_syn/test_prbs_generator_syn.py
+++ b/tests/test_prbs_generator_syn/test_prbs_generator_syn.py
@@ -1,0 +1,81 @@
+# general imports
+import os
+import pytest
+import shutil
+from random import randint
+from pathlib import Path
+
+# AHA imports
+import fault
+import magma as m
+
+# DragonPHY-specific imports
+from dragonphy import get_file
+
+THIS_DIR = Path(__file__).parent.resolve()
+BUILD_DIR = THIS_DIR / 'build'
+if shutil.which('iverilog'):
+    SIMULATOR = 'iverilog'
+elif 'FPGA_SERVER' in os.environ:
+    SIMULATOR = 'vivado'
+else:
+    SIMULATOR = 'ncsim'
+
+def test_sim():
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'prbs_generator_syn'
+        io = m.IO(
+            clk=m.ClockIn,
+            rst=m.BitIn,
+            cke=m.BitIn,
+            init_val=m.In(m.Bits[32]),
+            eqn=m.In(m.Bits[32]),
+            inj_err=m.BitIn,
+            inv_chicken=m.In(m.Bits[2]),
+            out=m.BitOut
+        )
+
+    # create tester
+    t = fault.Tester(dut, dut.clk)
+
+    # initialize with the right equation
+    t.poke(dut.clk, 0)
+    t.poke(dut.rst, 1)
+    t.poke(dut.cke, 1)
+    t.poke(dut.init_val, 1)
+    t.poke(dut.eqn, 0b1100000)
+    t.poke(dut.inj_err, 0)
+    t.poke(dut.inv_chicken, 0b00)
+
+    # reset
+    for _ in range(3):
+        t.step(2)
+
+    # release from reset and run for a bit
+    t.poke(dut.rst, 0)
+    for _ in range(50):
+        t.step(2)
+
+    # inject an error
+    t.poke(dut.inj_err, 1)
+    for _ in range(10):
+        t.step(2)
+
+    # run for a bit
+    t.poke(dut.inj_err, 0)
+    for _ in range(50):
+        t.step(2)
+
+    # run the test
+    t.compile_and_run(
+        target='system-verilog',
+        simulator=SIMULATOR,
+        ext_srcs=[
+            get_file('vlog/new_chip_src/prbs/prbs_generator_syn.sv'),
+        ],
+        ext_model_file=True,
+        disp_type='realtime',
+        dump_waveforms=True,
+        directory=BUILD_DIR
+    )

--- a/vlog/new_chip_src/digital_core/dcore_debug_intf.sv
+++ b/vlog/new_chip_src/digital_core/dcore_debug_intf.sv
@@ -48,6 +48,7 @@ interface dcore_debug_intf import const_pack::*; (
     	logic sram_rstb;
     	logic cdr_rstb;
     	logic prbs_rstb;
+    	logic prbs_gen_rstb;
    		logic [ffe_gpack::shift_precision-1:0] ffe_shift [constant_gpack::channel_width-1:0];
     	logic signed [cmp_gpack::thresh_precision-1:0] cmp_thresh  [constant_gpack::channel_width-1:0];
     	logic [mlsd_gpack::shift_precision-1:0] mlsd_shift [constant_gpack::channel_width-1:0];
@@ -91,6 +92,7 @@ interface dcore_debug_intf import const_pack::*; (
 		input sram_rstb,
 		input cdr_rstb,
 		input prbs_rstb,
+	    input prbs_gen_rstb,
 		input ffe_shift,
 		input cmp_thresh,
 		input mlsd_shift,
@@ -147,6 +149,7 @@ interface dcore_debug_intf import const_pack::*; (
 		output sram_rstb,
 		output cdr_rstb,
 		output prbs_rstb,
+		output prbs_gen_rstb,
 		output ffe_shift,
 		output cmp_thresh,
 		output mlsd_shift,

--- a/vlog/new_chip_src/digital_core/digital_core.sv
+++ b/vlog/new_chip_src/digital_core/digital_core.sv
@@ -50,6 +50,7 @@ module digital_core import const_pack::*; (
     wire logic sram_rstb;
     wire logic cdr_rstb;
     wire logic prbs_rstb;
+    wire logic prbs_gen_rstb;
     wire logic signed [Nadc-1:0] adcout_unfolded [Nti+Nti_rep-1:0];
 
     wire logic signed [ffe_gpack::output_precision-1:0] estimated_bits [constant_gpack::channel_width-1:0];
@@ -94,6 +95,7 @@ module digital_core import const_pack::*; (
     assign sram_rstb        = ddbg_intf_i.sram_rstb && ext_rstb;
     assign cdr_rstb         = ddbg_intf_i.cdr_rstb  && ext_rstb;
     assign prbs_rstb        = ddbg_intf_i.prbs_rstb && ext_rstb;
+    assign prbs_gen_rstb    = ddbg_intf_i.prbs_gen_rstb && ext_rstb;
 
     assign clk_cdr = clk_adc;
 
@@ -320,12 +322,12 @@ module digital_core import const_pack::*; (
     logic [Nti-1:0] bits_adc_r;
     logic [Nti-1:0] bits_ffe_r;
     logic [Nti-1:0] bits_mlsd_r;
+    logic bit_bist_r;
 
     assign mux_prbs_rx_bits[0] = bits_adc_r;
     assign mux_prbs_rx_bits[1] = bits_ffe_r;
     assign mux_prbs_rx_bits[2] = bits_mlsd_r;
-    assign mux_prbs_rx_bits[3] = 0;
-
+    assign mux_prbs_rx_bits[3] = {Nti{bit_bist_r}};
 
     generate
         for (k=0; k<Nti; k=k+1) begin
@@ -337,6 +339,28 @@ module digital_core import const_pack::*; (
 
     assign prbs_rx_bits = mux_prbs_rx_bits[ddbg_intf_i.sel_prbs_mux];
 
+    // PRBS generator for BIST
+    prbs_generator_syn #(
+        .n_prbs(Nprbs)
+    ) prbs_generator_syn_i (
+        // clock and reset
+        .clk(clk_adc),
+        .rst(~prbs_gen_rstb),
+        // clock gating
+        .cke(pdbg_intf_i.prbs_gen_cke),
+        // define the PRBS initialization
+        .init_val(pdbg_intf_i.prbs_gen_init),
+        // define the PRBS equation
+        .eqn(pdbg_intf_i.prbs_gen_eqn),
+        // signal for injecting errors
+        .inj_err(pdbg_intf_i.prbs_gen_inj_err),
+        // "chicken" bits for flipping the sign of various bits
+        .inv_chicken(pdbg_intf_i.prbs_gen_chicken),
+        // output bit
+        .out(bit_bist_r)
+    );
+
+    // PRBS checker
     prbs_checker #(
         .n_prbs(Nprbs),
         .n_channels(Nti)

--- a/vlog/new_chip_src/jtag/jtag.sv
+++ b/vlog/new_chip_src/jtag/jtag.sv
@@ -162,6 +162,7 @@ module jtag (
 	assign ddbg_intf_i.sram_rstb 	 = rjtag_intf_i.sram_rstb;
 	assign ddbg_intf_i.cdr_rstb 	 = rjtag_intf_i.cdr_rstb;
     assign ddbg_intf_i.prbs_rstb 	 = rjtag_intf_i.prbs_rstb;
+    assign ddbg_intf_i.prbs_gen_rstb = rjtag_intf_i.prbs_gen_rstb;
 
 	assign ddbg_intf_i.disable_product	= rjtag_intf_i.disable_product;
 	assign ddbg_intf_i.ffe_shift		= rjtag_intf_i.ffe_shift;
@@ -219,17 +220,24 @@ module jtag (
 
 
 
-    // PRBS Input
+    // PRBS Checker Input
     assign pdbg_intf_i.prbs_cke = rjtag_intf_i.prbs_cke;
     assign pdbg_intf_i.prbs_eqn = rjtag_intf_i.prbs_eqn;
     assign pdbg_intf_i.prbs_chan_sel = rjtag_intf_i.prbs_chan_sel;
     assign pdbg_intf_i.prbs_inv_chicken = rjtag_intf_i.prbs_inv_chicken;
     assign pdbg_intf_i.prbs_checker_mode = rjtag_intf_i.prbs_checker_mode;
-    // PRBS Output
+    // PRBS Checker Output
     assign rjtag_intf_i.prbs_err_bits_upper = pdbg_intf_i.prbs_err_bits_upper;
     assign rjtag_intf_i.prbs_err_bits_lower = pdbg_intf_i.prbs_err_bits_lower;
     assign rjtag_intf_i.prbs_total_bits_upper = pdbg_intf_i.prbs_total_bits_upper;
     assign rjtag_intf_i.prbs_total_bits_lower = pdbg_intf_i.prbs_total_bits_lower;
+
+    // PRBS Generator Input (for BIST)
+    assign pdbg_intf_i.prbs_gen_cke = rjtag_intf_i.prbs_gen_cke;
+    assign pdbg_intf_i.prbs_gen_init = rjtag_intf_i.prbs_gen_init;
+    assign pdbg_intf_i.prbs_gen_eqn = rjtag_intf_i.prbs_gen_eqn;
+    assign pdbg_intf_i.prbs_gen_inj_err = rjtag_intf_i.prbs_gen_inj_err;
+    assign pdbg_intf_i.prbs_gen_chicken = rjtag_intf_i.prbs_gen_chicken;
 
     //WME Input
     assign wdbg_intf_i.wme_ffe_data  = rjtag_intf_i.wme_ffe_data;

--- a/vlog/new_chip_src/prbs/prbs_debug_intf.sv
+++ b/vlog/new_chip_src/prbs/prbs_debug_intf.sv
@@ -13,6 +13,12 @@ interface prbs_debug_intf;
     logic [31:0] prbs_total_bits_upper;
     logic [31:0] prbs_total_bits_lower;
 
+    logic prbs_gen_cke;
+    logic [(Nprbs-1):0] prbs_gen_init;
+    logic [(Nprbs-1):0] prbs_gen_eqn;
+    logic prbs_gen_inj_err;
+    logic [1:0] prbs_gen_chicken;
+
     modport prbs (
         input prbs_cke,
         input prbs_eqn,
@@ -22,7 +28,12 @@ interface prbs_debug_intf;
         output prbs_err_bits_upper,
         output prbs_err_bits_lower,
         output prbs_total_bits_upper,
-        output prbs_total_bits_lower
+        output prbs_total_bits_lower,
+        input prbs_gen_cke,
+        input prbs_gen_init,
+        input prbs_gen_eqn,
+        input prbs_gen_inj_err,
+        input prbs_gen_chicken
     );
 
     modport jtag (
@@ -34,6 +45,11 @@ interface prbs_debug_intf;
         input prbs_err_bits_upper,
         input prbs_err_bits_lower,
         input prbs_total_bits_upper,
-        input prbs_total_bits_lower
+        input prbs_total_bits_lower,
+        output prbs_gen_cke,
+        output prbs_gen_init,
+        output prbs_gen_eqn,
+        output prbs_gen_inj_err,
+        output prbs_gen_chicken
     );
 endinterface

--- a/vlog/new_chip_src/prbs/prbs_generator_syn.sv
+++ b/vlog/new_chip_src/prbs/prbs_generator_syn.sv
@@ -1,0 +1,81 @@
+`default_nettype none
+
+module prbs_generator_syn #(
+    parameter integer n_prbs=32
+) (
+    // basic clock and reset for this block
+    input wire logic clk,
+    input wire logic rst,
+
+    // clock gating
+    input wire logic cke,
+
+    // define the PRBS initialization
+    input wire logic [(n_prbs-1):0] init_val,
+
+    // define the PRBS equation
+    input wire logic [(n_prbs-1):0] eqn,
+
+    // signal for injecting errors
+    input wire logic inj_err,
+
+    // "chicken" bits for flipping the sign of various bits
+    input wire logic [1:0] inv_chicken,
+
+    // output
+    output wire logic out
+);
+    // register inj_err signal
+    logic [3:0] inj_err_mem;
+    always @(posedge clk) begin
+        if (rst) begin
+            inj_err_mem <= 0;
+        end else if (cke) begin
+            inj_err_mem <= {inj_err_mem[2:0], inj_err};
+        end else begin
+            inj_err_mem <= inj_err_mem;
+        end
+    end
+
+    // determine if we should inject an error
+    // this should happen on the rising edge of inj_err
+    logic inj_error_pulse;
+    assign inj_error_pulse = (~inj_err_mem[3]) & (inj_err_mem[2]);
+
+    // select bits for the LFSR equation
+    logic [(n_prbs-1):0] prbs_state;
+    logic [(n_prbs-1):0] prbs_select;
+    assign prbs_select = prbs_state & eqn;
+
+    // xor selected bits
+    logic prbs_xor;
+    assign prbs_xor = ^prbs_select;
+
+    // update the LFSR state
+    always @(posedge clk) begin
+        if (rst) begin
+            prbs_state <= init_val;
+        end else if (cke) begin
+            prbs_state <= {prbs_state[(n_prbs-2):0], (prbs_xor^inv_chicken[0])};
+        end else begin
+            prbs_state <= prbs_state;
+        end
+    end
+
+    // compute output
+    logic out_reg;
+    always @(posedge clk) begin
+        if (rst) begin
+            out_reg <= 0;
+        end else if (cke) begin
+            out_reg <= prbs_state[n_prbs-1] ^ inj_error_pulse ^ inv_chicken[1];
+        end else begin
+            out_reg <= out_reg;
+        end
+    end
+
+    // output assignment
+    assign out = out_reg;
+endmodule
+
+`default_nettype wire


### PR DESCRIPTION
Since we had an open slot on the mux going into the PRBS checker, I thought it would be nice to use it for running a self-test, so this PR connects a PRBS generator to the mux.  One of the key features of the generator is the ability to produce single-bit errors on demand.  Hopefully this BIST will be helpful for lab debug.