### PR TITLE
MM CDR test + other test updates

### DIFF
--- a/dragonphy/experiment/calc_ffe_coeff.py
+++ b/dragonphy/experiment/calc_ffe_coeff.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+dt = 1/16e9
+tau = dt
+
+def ch_resp(n):
+    return (1-np.exp(-(n+1)*dt/tau))*np.heaviside(n+1, 0.5) \
+           - (1-np.exp(-n*dt/tau))*np.heaviside(n, 0.5)
+
+depth = 5
+eqn = np.zeros((depth, depth), dtype=float)
+for k in range(depth):
+    eqn[k, :] = ch_resp(np.array(range(k, k-depth, -1)))
+
+vec = np.zeros(depth, dtype=float)
+vec[0] = 1.0
+
+x = np.linalg.solve(eqn, vec)
+print(x)
+
+print(1.0/(1-np.exp(-dt/tau)))
+print(-np.exp(-dt/tau)/(1-np.exp(-dt/tau)))

--- a/tests/new_tests/AC/test.sv
+++ b/tests/new_tests/AC/test.sv
@@ -80,14 +80,12 @@ module test;
 	// Save signals for post-processing
 
 	logic should_record;
-	logic recording_clk;
-    logic signed [Nadc-1:0] adcout_unfolded [Nti-1:0];
    
 	 ti_adc_recorder #(
         .filename(`TI_ADC_TXT)
     ) ti_adc_recorder_i (
-		.in(adcout_unfolded),
-		.clk(recording_clk),
+		.in(top_i.idcore.adcout_unfolded[15:0]),
+		.clk(top_i.idcore.clk_adc),
 		.en(should_record)
 	);
 
@@ -102,48 +100,10 @@ module test;
 		.ch_outn(ch_outn)
 	);
 
-    // Re-ordering
-    // TODO: clean this up because it is likely a real bug
-	
-	integer tmp;
-	//teger idx_order [Nti] = '{0, 5, 10, 15,
-	//                         1, 6, 11, 12,
-	//                         2, 7,  8, 13,
-	//                         3, 4,  9, 14};
-	
-    integer idx_order [Nti] = '{0, 4, 8, 12,
-	                         	1, 5, 9, 13,
-	                         	2, 6, 10, 14,
-	                         	3, 7, 11, 15};
-    
-	always @(posedge top_i.idcore.clk_adc) begin
-        // compute the unfolded ADC outputs
-        for (int k=0; k<Nti; k=k+1) begin
-            // compute output
-             tmp = top_i.idcore.adcout_sign[idx_order[k]] ?
-                  top_i.idcore.adcout[idx_order[k]] - (`EXT_PFD_OFFSET) :
-                  (`EXT_PFD_OFFSET) - top_i.idcore.adcout[idx_order[k]];
-			
-			// clamp
-            if (tmp > 127) begin
-                tmp = 127;
-            end
-            if (tmp < -128) begin
-                tmp = -128;
-            end
-            // assign to output vector
-            adcout_unfolded[k] = tmp;
-        end
-        // pulse the recording clock
-        recording_clk = 1'b1;
-        #(1ps);
-        recording_clk = 1'b0;
-        #(1ps);
-    end
-
 	// Main test
 
 	logic [Nadc-1:0] tmp_ext_pfd_offset [Nti-1:0];
+    logic [Npi-1:0] tmp_bypass_pi_ctl [Nout-1:0];
 
 	initial begin
         `ifdef DUMP_WAVEFORMS
@@ -153,7 +113,6 @@ module test;
 
         // initialize control signals
 		should_record = 1'b0;
-		recording_clk = 1'b0;
         rstb = 1'b0;
         #(1ns);
 
@@ -187,10 +146,12 @@ module test;
 
         // apply the stimulus
         $display("Setting up the PI control codes...");
-        force top_i.idcore.int_pi_ctl_cdr[0] = 0;
-        force top_i.idcore.int_pi_ctl_cdr[1] = 67;
-        force top_i.idcore.int_pi_ctl_cdr[2] = 133;
-        force top_i.idcore.int_pi_ctl_cdr[3] = 200;
+        tmp_bypass_pi_ctl[0] = 0;
+        tmp_bypass_pi_ctl[1] = 67;
+        tmp_bypass_pi_ctl[2] = 133;
+        tmp_bypass_pi_ctl[3] = 200;
+        `FORCE_JTAG(bypass_pi_ctl, tmp_bypass_pi_ctl);
+        `FORCE_JTAG(en_bypass_pi_ctl, 1);
         #(5ns);
 
         // toggle the en_v2t signal to re-initialize the V2T ordering

--- a/tests/new_tests/AC/test.sv
+++ b/tests/new_tests/AC/test.sv
@@ -1,8 +1,6 @@
 `include "mLingua_pwl.vh"
-//`include "mdll_param.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 
 `ifndef TI_ADC_TXT
     `define TI_ADC_TXT
@@ -170,13 +168,13 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(64ns);
 
         // Set up the PFD offset
@@ -184,7 +182,7 @@ module test;
         for (int idx=0; idx<Nti; idx=idx+1) begin
             tmp_ext_pfd_offset[idx] = `EXT_PFD_OFFSET;
         end
-        `FORCE_DDBG(ext_pfd_offset, tmp_ext_pfd_offset);
+        `FORCE_JTAG(ext_pfd_offset, tmp_ext_pfd_offset);
         #(1ns);
 
         // apply the stimulus
@@ -196,9 +194,9 @@ module test;
         #(5ns);
 
         // toggle the en_v2t signal to re-initialize the V2T ordering
-        `FORCE_ADBG(en_v2t, 0);
+        `FORCE_JTAG(en_v2t, 0);
         #(5ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(5ns);
 
 		// Wait some time initially

--- a/tests/new_tests/AC_REPLICA/test.sv
+++ b/tests/new_tests/AC_REPLICA/test.sv
@@ -1,7 +1,6 @@
 `include "mLingua_pwl.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 
 `ifndef TI_ADC_TXT
     `define TI_ADC_TXT
@@ -126,24 +125,24 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(1ns);
 
         // Enable the replica slices
-        `FORCE_ADBG(en_slice_rep, (1<<(Nti_rep))-1);
+        `FORCE_JTAG(en_slice_rep, (1<<(Nti_rep))-1);
         #(1ns);
 
         // Set up the PFD offset
         for (int idx=0; idx<Nti_rep; idx=idx+1) begin
             tmp_ext_pfd_offset_rep[idx] = `EXT_PFD_OFFSET;
         end
-        `FORCE_DDBG(ext_pfd_offset_rep, tmp_ext_pfd_offset_rep);
+        `FORCE_JTAG(ext_pfd_offset_rep, tmp_ext_pfd_offset_rep);
         #(1ns);
 
 		// Wait some time initially

--- a/tests/new_tests/DC/test.sv
+++ b/tests/new_tests/DC/test.sv
@@ -1,7 +1,6 @@
 `include "mLingua_pwl.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 
 `ifndef RX_INPUT_TXT
     `define RX_INPUT_TXT
@@ -152,13 +151,13 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(1ns);
 
         // Set up the PFD offset
@@ -166,7 +165,7 @@ module test;
         for (int idx=0; idx<Nti; idx=idx+1) begin
             tmp_ext_pfd_offset[idx] = `EXT_PFD_OFFSET;
         end
-        `FORCE_DDBG(ext_pfd_offset, tmp_ext_pfd_offset);
+        `FORCE_JTAG(ext_pfd_offset, tmp_ext_pfd_offset);
         #(64ns);
 
         // Walk through differential input voltages

--- a/tests/new_tests/DC_REPLICA/test.sv
+++ b/tests/new_tests/DC_REPLICA/test.sv
@@ -1,7 +1,6 @@
 `include "mLingua_pwl.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 
 `ifndef RX_INPUT_TXT
     `define RX_INPUT_TXT
@@ -156,18 +155,18 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(1ns);
 
         // Enable replica slices
         $display("Enable replica slices...");
-        `FORCE_ADBG(en_slice_rep, (1<<(Nti_rep))-1);
+        `FORCE_JTAG(en_slice_rep, (1<<(Nti_rep))-1);
         #(1ns);
 
         // Set up the PFD offset
@@ -175,7 +174,7 @@ module test;
         for (int idx=0; idx<Nti_rep; idx=idx+1) begin
             tmp_ext_pfd_offset_rep[idx] = `EXT_PFD_OFFSET;
         end
-        `FORCE_DDBG(ext_pfd_offset_rep, tmp_ext_pfd_offset_rep);
+        `FORCE_JTAG(ext_pfd_offset_rep, tmp_ext_pfd_offset_rep);
         #(1ns);
 
         // Walk through differential input voltages

--- a/tests/new_tests/GLITCH/test.sv
+++ b/tests/new_tests/GLITCH/test.sv
@@ -26,10 +26,6 @@
     `define WIDTH_TOL 2e-12
 `endif
 
-`ifndef INITIAL_CODE
-    `define INITIAL_CODE 0
-`endif
-
 `ifndef INITIAL_DIR
     `define INITIAL_DIR +1
 `endif
@@ -94,22 +90,12 @@ module test;
     // Stimulus logic
     logic [(Npi-1):0] pi_ctl_indiv [(Nout-1):0];
     logic [(Npi-1):0] pi_ctl_prev [(Nout-1):0];
-    integer delay_val_ps [(Nout-1):0][(Npi-1):0];
     genvar ig;
     genvar jg;
     generate
         for (ig=0; ig<Nout; ig=ig+1) begin
-            for (jg=0; jg<Npi; jg=jg+1) begin
-                always @(pi_ctl_indiv[ig]) begin
-                    // randomize bit during setup
-                    #(1ps);
-                    force top_i.iacore.ctl_pi[ig][jg] = $urandom;
-
-                    // use a randomized setup time for each bit (all less than 500 ps)
-                    delay_val_ps[ig][jg] = $urandom%500;
-                    #(delay_val_ps[ig][jg]*1ps);
-                    force top_i.iacore.ctl_pi[ig][jg] = pi_ctl_indiv[ig][jg];
-                end
+            always @(pi_ctl_indiv[ig]) begin
+                force top_i.iacore.ctl_pi[ig] = pi_ctl_indiv[ig];
             end
         end
     endgenerate
@@ -132,9 +118,9 @@ module test;
     	test_start = 1'b0;
     	test_stop = 1'b0;
     	pi_ctl_indiv[0] = 0;
-        pi_ctl_indiv[1] = 67;
-        pi_ctl_indiv[2] = 133;
-        pi_ctl_indiv[3] = 200;
+        pi_ctl_indiv[1] = 0;
+        pi_ctl_indiv[2] = 0;
+        pi_ctl_indiv[3] = 0;
         for (int i=0; i<Nout; i=i+1) begin
     	    code_delta[i] = (`INITIAL_DIR);
     	end

--- a/tests/new_tests/GLITCH/test.sv
+++ b/tests/new_tests/GLITCH/test.sv
@@ -102,6 +102,7 @@ module test;
             for (jg=0; jg<Npi; jg=jg+1) begin
                 always @(pi_ctl_indiv[ig]) begin
                     // randomize bit during setup
+                    #(1ps);
                     force top_i.iacore.ctl_pi[ig][jg] = $urandom;
 
                     // use a randomized setup time for each bit (all less than 500 ps)

--- a/tests/new_tests/GLITCH/test.sv
+++ b/tests/new_tests/GLITCH/test.sv
@@ -1,10 +1,7 @@
 `timescale 1fs/1fs
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
-`define FORCE_IDCORE(name, value) force top_i.idcore.``name`` = ``value``
-
-`define GET_ADBG(name) top_i.iacore.adbg_intf_i.``name``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
+`define GET_JTAG(name) top_i.idcore.jtag_i.rjtag_intf_i.``name``
 
 // please set the values for these variables in the Python script!
 // documentation for each can be found there
@@ -135,13 +132,13 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(1ns);
 
         // wait for startup so that we can read max_sel_mux
@@ -151,7 +148,7 @@ module test;
         // the expression for the max value is from Sung-Jin on May 1, 2020
         max_max_ctl_pi = 0;
         for (int i=0; i<Nout; i=i+1) begin
-            max_sel_mux[i] = `GET_ADBG(max_sel_mux[i]);
+            max_sel_mux[i] = `GET_JTAG(max_sel_mux[i]);
             max_ctl_pi[i] = ((max_sel_mux[i]+1)*16)-1;
             if (max_ctl_pi[i] > max_max_ctl_pi) begin
                 max_max_ctl_pi = max_ctl_pi[i];

--- a/tests/new_tests/GLITCH/test_glitch.py
+++ b/tests/new_tests/GLITCH/test_glitch.py
@@ -15,7 +15,7 @@ else:
 
 # Set DUMP_WAVEFORMS to True if you want to dump all waveforms for this
 # test.  The waveforms are stored in tests/new_tests/GLITCH/build/waves.shm
-DUMP_WAVEFORMS = True
+DUMP_WAVEFORMS = False
 
 @pytest.mark.parametrize((), [pytest.param(marks=pytest.mark.slow) if SIMULATOR=='vivado' else ()])
 def test_sim():

--- a/tests/new_tests/GLITCH/test_glitch.py
+++ b/tests/new_tests/GLITCH/test_glitch.py
@@ -15,7 +15,7 @@ else:
 
 # Set DUMP_WAVEFORMS to True if you want to dump all waveforms for this
 # test.  The waveforms are stored in tests/new_tests/GLITCH/build/waves.shm
-DUMP_WAVEFORMS = False
+DUMP_WAVEFORMS = True
 
 @pytest.mark.parametrize((), [pytest.param(marks=pytest.mark.slow) if SIMULATOR=='vivado' else ()])
 def test_sim():
@@ -42,10 +42,8 @@ def test_sim():
         # the worst-case resolution of the PI
         'WIDTH_TOL': 2e-12,
 
-        # what is the initial code and code change direction?
-        # INITIAL_CODE can be 0 through (2**Npi)-1
+        # what is the initial code change direction?
         # INITIAL_DIR can be either +1 (increasing) or -1 (decreasing)
-        'INITIAL_CODE': 0,
         'INITIAL_DIR': +1,
 
         # PI and CDR clock frequencies.  Probably don't have

--- a/tests/new_tests/INPUT_BUFFER/test.sv
+++ b/tests/new_tests/INPUT_BUFFER/test.sv
@@ -1,7 +1,6 @@
 `include "mLingua_pwl.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 
 module test;
 
@@ -76,13 +75,13 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(1ns);
 
         // Wait a little while

--- a/tests/new_tests/LOOPBACK_RETIMER/test.sv
+++ b/tests/new_tests/LOOPBACK_RETIMER/test.sv
@@ -1,8 +1,6 @@
 `include "mLingua_pwl.vh"
-//`include "mdll_param.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 
 `ifndef TI_ADC_TXT
     `define TI_ADC_TXT
@@ -186,13 +184,13 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(64ns);
 
         // Set up the PFD offset
@@ -200,7 +198,7 @@ module test;
         for (int idx=0; idx<Nti; idx=idx+1) begin
             tmp_ext_pfd_offset[idx] = `EXT_PFD_OFFSET;
         end
-        `FORCE_DDBG(ext_pfd_offset, tmp_ext_pfd_offset);
+        `FORCE_JTAG(ext_pfd_offset, tmp_ext_pfd_offset);
         #(1ns);
 
         // apply the stimulus
@@ -212,9 +210,9 @@ module test;
         #(5ns);
 
         // toggle the en_v2t signal to re-initialize the V2T ordering
-        `FORCE_ADBG(en_v2t, 0);
+        `FORCE_JTAG(en_v2t, 0);
         #(5ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(5ns);
 
 		// Wait some time initially

--- a/tests/new_tests/MM_CDR/test.sv
+++ b/tests/new_tests/MM_CDR/test.sv
@@ -1,160 +1,275 @@
 `include "mLingua_pwl.vh"
-`include "iotype.sv"
 
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
+`define GET_JTAG(name) top_i.idcore.jtag_i.rjtag_intf_i.``name``
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
-`define FORCE_CDBG(name, value) force top_i.idcore.cdbg_intf_i.``name`` = ``value``
-
-
-`default_nettype none
+`ifndef EXT_PFD_OFFSET
+    `define EXT_PFD_OFFSET 16
+`endif
 
 module test;
 
 	import const_pack::*;
 	import test_pack::*;
-	import checker_pack::*;
 	import jtag_reg_pack::*;
 
-	localparam `real_t v_cm = 0.25;
-
-	// mLingua initialization
-	PWLMethod pm=new;
-
-	// Analog inputs
-	`pwl_t ch_outp;
-	`pwl_t ch_outn;
-
-	// Clock inputs 
-	logic clk_async;
-	logic clk_jm_p;
-	logic clk_jm_n;
+    // clock inputs
 	logic ext_clkp;
 	logic ext_clkn;
-	
-	// Clock outputs
-	logic clk_out_p;
-	logic clk_out_n;
-	logic clk_trig_p;
-	logic clk_trig_n;
-	logic clk_retime;
-	logic clk_slow;
-    logic rstb;
-	
-	// Dump control
-	logic dump_start;
-	
+
+	// reset
+	logic rstb;
+
 	// JTAG
 	jtag_intf jtag_intf_i();
+    jtag_drv jtag_drv_i (jtag_intf_i);
+
+	// Analog inputs
+
+	pwl ch_outp;
+	pwl ch_outn;
+
+    real inp, inn;
+    assign inp = ch_outp.a;
+    assign inn = ch_outn.a;
 
 	// instantiate top module
+
 	dragonphy_top top_i (
 	    // analog inputs
 		.ext_rx_inp(ch_outp),
 		.ext_rx_inn(ch_outn),
-		.ext_Vcm(v_cm),
-		// clock inputs
+
+		// external clocks
 		.ext_clkp(ext_clkp),
 		.ext_clkn(ext_clkn),
 
-        // reset
+		// reset
         .ext_rstb(rstb),
 
         // JTAG
 		.jtag_intf_i(jtag_intf_i)
-		// other I/O not used..
+
+		// other I/O not used...
 	);
 
-	localparam real ext_clk_freq = full_rate/2;
+    // prbs stimulus
+
+    logic tx_clk;
+    logic tx_data;
+
+    tx_prbs #(
+        .freq(full_rate),
+        .td(34.7e-12)
+    ) tx_prbs_i (
+        .clk(tx_clk),
+        .out(tx_data)
+    );
+
+    // TX driver
+
+    pwl tx_p;
+    pwl tx_n;
+
+    diff_tx_driver diff_tx_driver_i (
+        .in(tx_data),
+        .out_p(tx_p),
+        .out_n(tx_n)
+    );
+
+    // Differential channel
+
+    diff_channel #(
+        .tau(14.2e-12)
+    ) diff_channel_i (
+        .in_p(tx_p),
+        .in_n(tx_n),
+        .out_p(ch_outp),
+        .out_n(ch_outn)
+    );
+
+	// External clock
+
 	clock #(
-		.freq(ext_clk_freq), // Depends on divider!
+		.freq(full_rate/2), // This depends on the frequency divider in the ACORE's input buffer
 		.duty(0.5),
 		.td(0)
 	) iEXTCLK (
 		.ckout(ext_clkp),
 		.ckoutb(ext_clkn)
-	); 
-
-	jtag_drv jtag_drv_i (jtag_intf_i);
-
-	// TX data
-	// Save TX output and RX ADC data
-
-	logic should_record;
-	
-	ti_adc_recorder ti_adc_recorder_i (
-		.in(top_i.idcore.adcout_unfolded[Nti-1:0]),
-		.clk(top_i.clk_adc),
-		.en(should_record)
 	);
 
+    //  Main test
+
+	logic [Nadc-1:0] tmp_ext_pfd_offset [Nti-1:0];
+    logic [Npi-1:0] tmp_ext_pi_ctl_offset [Nout-1:0];
+    logic [Nprbs-1:0] tmp_prbs_eqn;
+
+    integer loop_var;
+    integer offset;
+
+    longint err_bits, total_bits;
+
 	initial begin
-		$shm_open("waves.shm"); $shm_probe("ASMC");
-		$shm_probe(top_i.idcore.iMM_CDR.phase_est_out);
-		$shm_probe(top_i.idcore.iMM_CDR.phase_est_d);
-		$shm_probe(top_i.idcore.iMM_CDR.phase_est_q);
-		$shm_probe(top_i.idcore.iMM_CDR.phase_est_update);
-		$shm_probe(top_i.idcore.iMM_CDR.freq_diff);
-		$shm_probe(top_i.idcore.iMM_CDR.freq_est_d);
-		$shm_probe(top_i.idcore.iMM_CDR.freq_est_q);
-		$shm_probe(top_i.idcore.iMM_CDR.freq_est_update);
-        $shm_probe(top_i.idcore.iMM_CDR.phase_error);
-		$shm_probe(top_i.idcore.iMM_CDR.scaled_pi_ctl);
-		$shm_probe(top_i.idcore.iMM_CDR.pi_ctl);
-		$shm_probe(top_i.idcore.iMM_CDR.wait_on_reset_b);
-		$shm_probe(top_i.idcore.iMM_CDR.wait_on_reset_ii);
-		$shm_probe(top_i.idcore.iMM_CDR.din);
-		$shm_probe(top_i.idcore.mm_cdr_input);
-        $shm_probe(top_i.idcore.cdbg_intf_i.sel_inp_mux);
-        $shm_probe(top_i.idcore.cdbg_intf_i.en_freq_est);
-        $shm_probe(top_i.idcore.iMM_CDR.phase_error_inv);
-        $shm_probe(top_i.idcore.iMM_CDR.pd_phase_error);
+        `ifdef DUMP_WAVEFORMS
+            // Set up probing
+            $shm_open("waves.shm");
 
+            // MM CDR instance
+            $shm_probe(top_i.idcore.iMM_CDR.pi_ctl);
+            $shm_probe(top_i.idcore.iMM_CDR.phase_error);
+            $shm_probe(top_i.idcore.iMM_CDR.phase_est_update);
+            $shm_probe(top_i.idcore.iMM_CDR.phase_est_d);
+            $shm_probe(top_i.idcore.iMM_CDR.phase_est_out);
 
+            // Calculating PI control codes
+            $shm_probe(top_i.idcore.scale_value);
+            $shm_probe(top_i.idcore.unscaled_pi_ctl);
+            $shm_probe(top_i.idcore.scaled_pi_ctl);
+            $shm_probe(top_i.idcore.int_pi_ctl_cdr);
+            $shm_probe(top_i.idcore.ddbg_intf_i.ext_pi_ctl_offset);
+            $shm_probe(top_i.idcore.ddbg_intf_i.en_ext_max_sel_mux);
+            $shm_probe(top_i.idcore.ddbg_intf_i.en_bypass_pi_ctl);
+            $shm_probe(top_i.idcore.ddbg_intf_i.bypass_pi_ctl);
+            $shm_probe(top_i.iacore.adbg_intf_i.max_sel_mux);
 
-		// signal initialization
+            // Number of error bits
+            $shm_probe(top_i.idcore.prbs_checker_i.err_bits);
+            $shm_probe(top_i.idcore.prbs_checker_i.err_signals);
+
+            // data in test bench
+            // $shm_probe(tx_clk);
+            // $shm_probe(tx_data);
+
+            // clocks in analog_core
+            $shm_probe(top_i.iacore.clk_interp_slice);
+            $shm_probe(top_i.iacore.clk_interp_sw);
+
+            // data in analog_core
+            $shm_probe(inp);
+            $shm_probe(inn);
+
+            // data in digital_core
+            // $shm_probe(top_i.idcore.adcout_unfolded);
+        `endif
+
+        // initialize control signals
 		rstb = 1'b0;
-		should_record = 'b0;
+        #(1ns);
 
-		// reset sequence
-		#(20ns);
+		// Release reset
+		$display("Releasing external reset...");
 		rstb = 1'b1;
+        #(1ns);
+
+        // Initialize JTAG
+        $display("Initializing JTAG...");
+        jtag_drv_i.init();
+
+        // Soft reset sequence
+        $display("Soft reset sequence...");
+        `FORCE_JTAG(int_rstb, 1);
+        #(1ns);
+        `FORCE_JTAG(en_inbuf, 1);
+		#(1ns);
+        `FORCE_JTAG(en_gf, 1);
+        #(1ns);
+        `FORCE_JTAG(en_v2t, 1);
+        #(64ns);
+
+        // Set up the PFD offset
+        $display("Setting up the PFD offset...");
+        for (int idx=0; idx<Nti; idx=idx+1) begin
+            tmp_ext_pfd_offset[idx] = `EXT_PFD_OFFSET;
+        end
+        `FORCE_JTAG(ext_pfd_offset, tmp_ext_pfd_offset);
+        #(1ns);
+
+        // Set the equation for the PRBS checker
+        $display("Setting the PRBS equation");
+        tmp_prbs_eqn = 0;
+        tmp_prbs_eqn[ 1] = 1'b1;
+        tmp_prbs_eqn[20] = 1'b1;
+        `FORCE_JTAG(prbs_eqn, tmp_prbs_eqn);
+        #(10ns);
+
+        // Release the PRBS checker from reset
+        $display("Release the PRBS tester from reset");
+        `FORCE_JTAG(prbs_rstb, 1);
+        #(50ns);
+
+        // Configure the CDR offsets
+        $display("Setting up the CDR offset...");
+        tmp_ext_pi_ctl_offset[0] =   0;
+        tmp_ext_pi_ctl_offset[1] = 135;
+        tmp_ext_pi_ctl_offset[2] = 270;
+        tmp_ext_pi_ctl_offset[3] = 405;
+        `FORCE_JTAG(ext_pi_ctl_offset, tmp_ext_pi_ctl_offset);
+        #(5ns);
+
+        // Configure the CDR
+      	$display("Configuring the CDR...");
+      	`FORCE_JTAG(Kp, 18);
+      	`FORCE_JTAG(Ki, 0);
+      	`FORCE_JTAG(invert, 1);
+		`FORCE_JTAG(en_freq_est, 0);
+		`FORCE_JTAG(en_ext_pi_ctl, 0);
 		#(10ns);
 
-		// JTAG writes
-		jtag_drv_i.init();
-
-		// Enable the input buffer
-		$display("Enabling input buffer...");
-      	`FORCE_DDBG(int_rstb, 1);
-      	`FORCE_CDBG(Kp, 2);
-      	`FORCE_CDBG(Ki, 0);
-      	`FORCE_CDBG(invert, 1);
-		`FORCE_CDBG(en_freq_est, 1);
-        #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
-		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
-        #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
-        #(1ns);
-        $display("Enabling V2T...");
-
-		$display("Disabling external PI CTL code...");
-		#(1us)
-
-		`FORCE_CDBG(en_ext_pi_ctl, 0);
-		$display("Enabling external offset for PI CTL...");
-		//jtag_drv_i.write_tc_reg(sel_ext_pd_offset, 'b1);
+        // Toggle the en_v2t signal to re-initialize the V2T ordering
+        $display("Toggling en_v2t...");
+        `FORCE_JTAG(en_v2t, 0);
+        #(5ns);
+        `FORCE_JTAG(en_v2t, 1);
+        #(5ns);
 
 		// Wait for MM_CDR to lock
 		$display("Waiting for MM_CDR to lock...");
-		#(40us);
+		for (loop_var=0; loop_var<2; loop_var=loop_var+1) begin
+		    $display("Interval %0d/2", loop_var);
+		    #(100ns);
+		end
 
-		// Record for a bit
-		$display("Recording input and output...");
-		should_record = 'b1;
-		#(100ns);
+        // Run the PRBS tester
+        $display("Running the PRBS tester");
+        `FORCE_JTAG(prbs_checker_mode, 2);
+        for (loop_var=0; loop_var<6; loop_var=loop_var+1) begin
+		    $display("Interval %0d/6", loop_var);
+		    #(100ns);
+		end
+        #(25ns);
+
+        // Get results
+        `FORCE_JTAG(prbs_checker_mode, 3);
+        #(10ns);
+
+        err_bits = 0;
+        err_bits |= `GET_JTAG(prbs_err_bits_upper);
+        err_bits <<= 32;
+        err_bits |= `GET_JTAG(prbs_err_bits_lower);
+
+        total_bits = 0;
+        total_bits |= `GET_JTAG(prbs_total_bits_upper);
+        total_bits <<= 32;
+        total_bits |= `GET_JTAG(prbs_total_bits_lower);
+
+        // Print results
+        $display("err_bits: %0d", err_bits);
+        $display("total_bits: %0d", total_bits);
+
+        // Check results
+
+        if (!(total_bits >= 9500)) begin
+            $error("Not enough bits transmitted");
+        end else begin
+            $display("Number of bits transmitted is OK");
+        end
+
+        if (!(err_bits == 0)) begin
+            $error("Bit error detected");
+        end else begin
+            $display("No bit errors detected");
+        end
 
 		// Finish test
 		$display("Test complete.");
@@ -162,5 +277,3 @@ module test;
 	end
 
 endmodule
-
-`default_nettype wire

--- a/tests/new_tests/MM_CDR/test_mm_cdr.py
+++ b/tests/new_tests/MM_CDR/test_mm_cdr.py
@@ -13,21 +13,19 @@ if 'FPGA_SERVER' in os.environ:
 else:
     SIMULATOR = 'ncsim'
 
-
+# Set DUMP_WAVEFORMS to True if you want to dump all waveforms for this
+# test.  The waveforms are stored in tests/new_tests/GLITCH/build/waves.shm
 DUMP_WAVEFORMS = False
 
-@pytest.mark.wip
+@pytest.mark.parametrize((), [pytest.param(marks=pytest.mark.slow) if SIMULATOR=='vivado' else ()])
 def test_sim():
     deps = get_deps_cpu_sim_new(impl_file=THIS_DIR / 'test.sv')
     print(deps)
 
-    def qwrap(s):
-        return f'"{s}"'
-
     defines = {
         'DAVE_TIMEUNIT': '1fs',
-        'SIMULATION' : None,
-        'NCVLOG': None
+        'NCVLOG': None,
+        'SIMULATION': None
     }
 
     flags = ['-unbuffered']
@@ -44,6 +42,3 @@ def test_sim():
         flags=flags,
         simulator=SIMULATOR
     ).run()
-
-if __name__ == "__main__":
-    test_sim()

--- a/tests/new_tests/OUTPUT_BUFFER/test.sv
+++ b/tests/new_tests/OUTPUT_BUFFER/test.sv
@@ -1,8 +1,6 @@
 `include "mLingua_pwl.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
-`define FORCE_IDCORE(name, value) force top_i.idcore.``name`` = ``value``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 
 module test;
 
@@ -157,31 +155,31 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(1ns);
 
         // Enable input buffer for the async clock
         $display("Enable input buffer for the async clock...");
-        `FORCE_IDCORE(disable_ibuf_async, 0);
+        `FORCE_JTAG(disable_ibuf_async, 0);
         #(1ns);
 
 		// Set up the output buffers
 		$display("Set up the output buffers...");
-		`FORCE_DDBG(en_outbuff, 1);
+		`FORCE_JTAG(en_outbuff, 1);
         #(1ns);
-        `FORCE_DDBG(en_trigbuff, 1);
+        `FORCE_JTAG(en_trigbuff, 1);
         #(1ns);
-        `FORCE_DDBG(sel_outbuff, 0);   // ADC clock
+        `FORCE_JTAG(sel_outbuff, 0);   // ADC clock
         #(1ns);
-        `FORCE_DDBG(sel_trigbuff, 12); // async clock
+        `FORCE_JTAG(sel_trigbuff, 12); // async clock
         #(1ns);
-        `FORCE_DDBG(en_cgra_clk, 1); // clock to CGRA
+        `FORCE_JTAG(en_cgra_clk, 1); // clock to CGRA
         #(1ns);
 
 		// Wait a little bit to measure frequencies

--- a/tests/new_tests/PI/test.sv
+++ b/tests/new_tests/PI/test.sv
@@ -1,10 +1,7 @@
 `include "mLingua_pwl.vh"
 
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
-`define FORCE_IDCORE(name, value) force top_i.idcore.``name`` = ``value``
-
-`define GET_ADBG(name) top_i.iacore.adbg_intf_i.``name``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
+`define GET_JTAG(name) top_i.idcore.jtag_i.rjtag_intf_i.``name``
 
 `ifndef PI_CTL_TXT
     `define PI_CTL_TXT
@@ -128,13 +125,13 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(64ns);
 
         // wait for startup so that we can read max_sel_mux
@@ -144,7 +141,7 @@ module test;
         // the expression for the max value is from Sung-Jin on May 1, 2020
         max_max_ctl_pi = 0;
         for (int i=0; i<Nout; i=i+1) begin
-            max_sel_mux[i] = `GET_ADBG(max_sel_mux[i]);
+            max_sel_mux[i] = `GET_JTAG(max_sel_mux[i]);
             max_ctl_pi[i] = ((max_sel_mux[i]+1)*16)-1;
             if (max_ctl_pi[i] > max_max_ctl_pi) begin
                 max_max_ctl_pi = max_ctl_pi[i];

--- a/tests/new_tests/PI_PM/test.sv
+++ b/tests/new_tests/PI_PM/test.sv
@@ -1,7 +1,5 @@
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
-`define FORCE_IDCORE(name, value) force top_i.idcore.``name`` = ``value``
-`define GET_ADBG(name) top_i.iacore.adbg_intf_i.``name``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
+`define GET_JTAG(name) top_i.idcore.jtag_i.rjtag_intf_i.``name``
 
 `ifndef PI_CTL_TXT
     `define PI_CTL_TXT
@@ -150,13 +148,13 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(1ns);
 
         // wait for startup so that we can read max_sel_mux
@@ -166,7 +164,7 @@ module test;
         // the expression for the max value is from Sung-Jin on May 1, 2020
         max_max_ctl_pi = 0;
         for (int i=0; i<Nout; i=i+1) begin
-            max_sel_mux[i] = `GET_ADBG(max_sel_mux[i]);
+            max_sel_mux[i] = `GET_JTAG(max_sel_mux[i]);
             max_ctl_pi[i] = ((max_sel_mux[i]+1)*16)-1;
             if (max_ctl_pi[i] > max_max_ctl_pi) begin
                 max_max_ctl_pi = max_ctl_pi[i];
@@ -175,12 +173,12 @@ module test;
 
         // Enable the async input buffer
         $display("Enable the async input buffer...");
-        `FORCE_IDCORE(disable_ibuf_async, 0);
+        `FORCE_JTAG(disable_ibuf_async, 0);
         #(1ns);
 
         // Enable external max_sel_mux
         $display("Enable external max_sel_mux...");
-        `FORCE_DDBG(en_ext_max_sel_mux, 1);
+        `FORCE_JTAG(en_ext_max_sel_mux, 1);
         #(1ns);
 
         // run desired number of trials
@@ -201,7 +199,7 @@ module test;
             tmp_sel_pm_sign_pi[1] = top_i.iacore.ctl_pi[1] < (`SIGN_FLIP) ? 1 : 0;
             tmp_sel_pm_sign_pi[2] = top_i.iacore.ctl_pi[2] < (`SIGN_FLIP) ? 1 : 0;
             tmp_sel_pm_sign_pi[3] = top_i.iacore.ctl_pi[3] < (`SIGN_FLIP) ? 1 : 0;
-            `FORCE_ADBG(sel_pm_sign_pi, tmp_sel_pm_sign_pi);
+            `FORCE_JTAG(sel_pm_sign_pi, tmp_sel_pm_sign_pi);
             #(1ns);
 
             // wait a few cycles of the 1 GHz clock
@@ -209,9 +207,9 @@ module test;
 
             // reset the PM
             $display("Resetting the PI PMs...");
-            `FORCE_ADBG(en_pm_pi, '0);
+            `FORCE_JTAG(en_pm_pi, '0);
             #(10ns);
-            `FORCE_ADBG(en_pm_pi, '1);
+            `FORCE_JTAG(en_pm_pi, '1);
 
             // wait a fixed amount of time
             $display("Waiting for the PM measurement...");
@@ -219,7 +217,7 @@ module test;
 
             // Compute delays
 			for (int j=0; j<Nout; j=j+1) begin
-			    pm_out_pi[j] = `GET_ADBG(pm_out_pi[j]);
+			    pm_out_pi[j] = `GET_JTAG(pm_out_pi[j]);
 				Tdelay[j] = 0.5/(1.0*`CLK_ASYNC_FREQ) * pm_out_pi[j] / (1.0*Nmax);
 			end
 

--- a/tests/new_tests/PRBS/test.sv
+++ b/tests/new_tests/PRBS/test.sv
@@ -1,8 +1,5 @@
-`define FORCE_ADBG(name, value) force top_i.iacore.adbg_intf_i.``name`` = ``value``
-`define FORCE_DDBG(name, value) force top_i.idcore.ddbg_intf_i.``name`` = ``value``
-`define FORCE_PDBG(name, value) force top_i.idcore.pdbg_intf_i.``name`` = ``value``
-
-`define GET_PDBG(name) top_i.idcore.pdbg_intf_i.``name``
+`define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
+`define GET_JTAG(name) top_i.idcore.jtag_i.rjtag_intf_i.``name``
 
 module test;
 	
@@ -68,77 +65,77 @@ module test;
 
         // Soft reset sequence
         $display("Soft reset sequence...");
-        `FORCE_DDBG(int_rstb, 1);
+        `FORCE_JTAG(int_rstb, 1);
         #(1ns);
-        `FORCE_ADBG(en_inbuf, 1);
+        `FORCE_JTAG(en_inbuf, 1);
 		#(1ns);
-        `FORCE_ADBG(en_gf, 1);
+        `FORCE_JTAG(en_gf, 1);
         #(1ns);
-        `FORCE_ADBG(en_v2t, 1);
+        `FORCE_JTAG(en_v2t, 1);
         #(64ns);
 
         // Turn on the PRBS generator
         $display("Turn on the PRBS generator (case 1)");
-        `FORCE_DDBG(prbs_gen_rstb, 1);
-        `FORCE_PDBG(prbs_gen_cke, 1);
+        `FORCE_JTAG(prbs_gen_rstb, 1);
+        `FORCE_JTAG(prbs_gen_cke, 1);
         #(50ns);
 
         // Select the PRBS checker data source
         $display("Select the PRBS checker data source (case 1)");
-        `FORCE_DDBG(sel_prbs_mux, 2'b11);
+        `FORCE_JTAG(sel_prbs_mux, 2'b11);
         #(10ns);
 
         // Release the PRBS checker from reset
         $display("Release the PRBS tester from reset (case 1)");
-        `FORCE_DDBG(prbs_rstb, 1);
+        `FORCE_JTAG(prbs_rstb, 1);
         #(50ns);
 
         // run the PRBS tester
         $display("Running the PRBS tester (case 1)");
-        `FORCE_PDBG(prbs_checker_mode, 2);
+        `FORCE_JTAG(prbs_checker_mode, 2);
         #(625ns);
 
         // get results
-        `FORCE_PDBG(prbs_checker_mode, 3);
+        `FORCE_JTAG(prbs_checker_mode, 3);
         #(10ns);
 
         err_bits_1 = 0;
-        err_bits_1 |= `GET_PDBG(prbs_err_bits_upper);
+        err_bits_1 |= `GET_JTAG(prbs_err_bits_upper);
         err_bits_1 <<= 32;
-        err_bits_1 |= `GET_PDBG(prbs_err_bits_lower);
+        err_bits_1 |= `GET_JTAG(prbs_err_bits_lower);
 
         total_bits_1 = 0;
-        total_bits_1 |= `GET_PDBG(prbs_total_bits_upper);
+        total_bits_1 |= `GET_JTAG(prbs_total_bits_upper);
         total_bits_1 <<= 32;
-        total_bits_1 |= `GET_PDBG(prbs_total_bits_lower);
+        total_bits_1 |= `GET_JTAG(prbs_total_bits_lower);
 
         // Reset the PRBS checker
         $display("Reset the PRBS tester (case 2)");
-        `FORCE_PDBG(prbs_checker_mode, 0);
+        `FORCE_JTAG(prbs_checker_mode, 0);
         #(50ns);
 
         // run the PRBS tester, but inject an error in the middle
         $display("Running the PRBS tester (case 2)");
-        `FORCE_PDBG(prbs_checker_mode, 2);
+        `FORCE_JTAG(prbs_checker_mode, 2);
         #(300ns);
-        `FORCE_PDBG(prbs_gen_inj_err, 1);
+        `FORCE_JTAG(prbs_gen_inj_err, 1);
         #(25ns);
-        `FORCE_PDBG(prbs_gen_inj_err, 0);
+        `FORCE_JTAG(prbs_gen_inj_err, 0);
         #(300ns);
 
         // get results
-        `FORCE_PDBG(prbs_checker_mode, 3);
+        `FORCE_JTAG(prbs_checker_mode, 3);
         #(10ns);
 
         err_bits_2 = 0;
-        err_bits_2 |= `GET_PDBG(prbs_err_bits_upper);
+        err_bits_2 |= `GET_JTAG(prbs_err_bits_upper);
         err_bits_2 <<= 32;
-        err_bits_2 |= `GET_PDBG(prbs_err_bits_lower);
+        err_bits_2 |= `GET_JTAG(prbs_err_bits_lower);
 
         total_bits_2 = 0;
-        total_bits_2 |= `GET_PDBG(prbs_total_bits_upper);
+        total_bits_2 |= `GET_JTAG(prbs_total_bits_upper);
         total_bits_2 <<= 32;
-        total_bits_2 |= `GET_PDBG(prbs_total_bits_lower);
+        total_bits_2 |= `GET_JTAG(prbs_total_bits_lower);
 
         // print results
         $display("err_bits_1: %0d", err_bits_1);

--- a/tests/new_tests/PRBS/test.sv
+++ b/tests/new_tests/PRBS/test.sv
@@ -1,6 +1,10 @@
 `define FORCE_JTAG(name, value) force top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
 `define GET_JTAG(name) top_i.idcore.jtag_i.rjtag_intf_i.``name``
 
+`ifndef EXT_PFD_OFFSET
+    `define EXT_PFD_OFFSET 16
+`endif
+
 module test;
 	
 	import const_pack::*;
@@ -18,14 +22,62 @@ module test;
 	jtag_intf jtag_intf_i();
     jtag_drv jtag_drv_i (jtag_intf_i);
 
+	// Analog inputs
+
+	pwl ch_outp;
+	pwl ch_outn;
+
 	// instantiate top module
+
 	dragonphy_top top_i (
+	    // analog inputs
+		.ext_rx_inp(ch_outp),
+		.ext_rx_inn(ch_outn),
+
+		// external clocks
 		.ext_clkp(ext_clkp),
 		.ext_clkn(ext_clkn),
+
+		// reset
         .ext_rstb(rstb),
+
+        // JTAG
 		.jtag_intf_i(jtag_intf_i)
+
 		// other I/O not used...
 	);
+
+    // prbs stimulus
+
+    logic tx_clk;
+    logic tx_data;
+
+    tx_prbs #(
+        .freq(full_rate)
+    ) tx_prbs_i (
+        .clk(tx_clk),
+        .out(tx_data)
+    );
+
+    // TX driver
+
+    pwl tx_p;
+    pwl tx_n;
+
+    diff_tx_driver diff_tx_driver_i (
+        .in(tx_data),
+        .out_p(tx_p),
+        .out_n(tx_n)
+    );
+
+    // Differential channel
+
+    diff_channel diff_channel_i (
+        .in_p(tx_p),
+        .in_n(tx_n),
+        .out_p(ch_outp),
+        .out_n(ch_outn)
+    );
 
 	// External clock
 
@@ -41,9 +93,14 @@ module test;
 	// Main test
 
 	logic [31:0] result;
+    longint err_bits_0, total_bits_0;
     longint err_bits_1, total_bits_1;
     longint err_bits_2, total_bits_2;
-    integer rx_shift;
+
+	logic [Nadc-1:0] tmp_ext_pfd_offset [Nti-1:0];
+    logic [Npi-1:0] tmp_bypass_pi_ctl [Nout-1:0];
+    logic [Nprbs-1:0] tmp_prbs_eqn;
+
 	initial begin
 		`ifdef DUMP_WAVEFORMS
 	        $shm_open("waves.shm");
@@ -74,6 +131,85 @@ module test;
         `FORCE_JTAG(en_v2t, 1);
         #(64ns);
 
+        // Set up the PFD offset
+        $display("Setting up the PFD offset...");
+        for (int idx=0; idx<Nti; idx=idx+1) begin
+            tmp_ext_pfd_offset[idx] = `EXT_PFD_OFFSET;
+        end
+        `FORCE_JTAG(ext_pfd_offset, tmp_ext_pfd_offset);
+        #(1ns);
+
+        // Configure the PI
+        $display("Setting up the PI control codes...");
+        tmp_bypass_pi_ctl[0] = 0;
+        tmp_bypass_pi_ctl[1] = 67;
+        tmp_bypass_pi_ctl[2] = 133;
+        tmp_bypass_pi_ctl[3] = 200;
+        `FORCE_JTAG(bypass_pi_ctl, tmp_bypass_pi_ctl);
+        `FORCE_JTAG(en_bypass_pi_ctl, 1);
+        #(5ns);
+
+        // Toggle the en_v2t signal to re-initialize the V2T ordering
+        $display("Toggling en_v2t...");
+        `FORCE_JTAG(en_v2t, 0);
+        #(5ns);
+        `FORCE_JTAG(en_v2t, 1);
+        #(5ns);
+
+		// Wait some time initially
+		$display("Initial delay of 100 ns...");
+		#(100ns);
+
+        /////////
+        // Case 0
+        /////////
+
+        // Set the equation for the PRBS checker
+        $display("Setting the PRBS equation (case 0)");
+        tmp_prbs_eqn = 0;
+        tmp_prbs_eqn[ 1] = 1'b1;
+        tmp_prbs_eqn[20] = 1'b1;
+        `FORCE_JTAG(prbs_eqn, tmp_prbs_eqn);
+        #(10ns);
+
+        // Release the PRBS checker from reset
+        $display("Release the PRBS tester from reset (case 0)");
+        `FORCE_JTAG(prbs_rstb, 1);
+        #(50ns);
+
+        // Run the PRBS tester
+        $display("Running the PRBS tester (case 0)");
+        `FORCE_JTAG(prbs_checker_mode, 2);
+        #(625ns);
+
+        // Get results
+        `FORCE_JTAG(prbs_checker_mode, 3);
+        #(10ns);
+
+        err_bits_0 = 0;
+        err_bits_0 |= `GET_JTAG(prbs_err_bits_upper);
+        err_bits_0 <<= 32;
+        err_bits_0 |= `GET_JTAG(prbs_err_bits_lower);
+
+        total_bits_0 = 0;
+        total_bits_0 |= `GET_JTAG(prbs_total_bits_upper);
+        total_bits_0 <<= 32;
+        total_bits_0 |= `GET_JTAG(prbs_total_bits_lower);
+
+        // Print results
+        $display("err_bits_0: %0d", err_bits_0);
+        $display("total_bits_0: %0d", total_bits_0);
+
+        /////////
+        // Case 1
+        /////////
+
+        // Set the equation for the PRBS checker
+        $display("Setting the PRBS equation (case 1)");
+        tmp_prbs_eqn = 32'b00000000000000000000000001100000;
+        `FORCE_JTAG(prbs_eqn, tmp_prbs_eqn);
+        #(10ns);
+
         // Turn on the PRBS generator
         $display("Turn on the PRBS generator (case 1)");
         `FORCE_JTAG(prbs_gen_rstb, 1);
@@ -85,9 +221,9 @@ module test;
         `FORCE_JTAG(sel_prbs_mux, 2'b11);
         #(10ns);
 
-        // Release the PRBS checker from reset
-        $display("Release the PRBS tester from reset (case 1)");
-        `FORCE_JTAG(prbs_rstb, 1);
+        // Reset the PRBS checker
+        $display("Reset the PRBS tester (case 1)");
+        `FORCE_JTAG(prbs_checker_mode, 0);
         #(50ns);
 
         // run the PRBS tester
@@ -108,6 +244,14 @@ module test;
         total_bits_1 |= `GET_JTAG(prbs_total_bits_upper);
         total_bits_1 <<= 32;
         total_bits_1 |= `GET_JTAG(prbs_total_bits_lower);
+
+        // Print results
+        $display("err_bits_1: %0d", err_bits_1);
+        $display("total_bits_1: %0d", total_bits_1);
+
+        /////////
+        // Case 2
+        /////////
 
         // Reset the PRBS checker
         $display("Reset the PRBS tester (case 2)");
@@ -138,12 +282,24 @@ module test;
         total_bits_2 |= `GET_JTAG(prbs_total_bits_lower);
 
         // print results
-        $display("err_bits_1: %0d", err_bits_1);
-        $display("total_bits_1: %0d", total_bits_1);
         $display("err_bits_2: %0d", err_bits_2);
         $display("total_bits_2: %0d", total_bits_2);
 
-        // check results
+        ////////////////
+        // Check results
+        ////////////////
+
+        if (!(total_bits_0 >= 9500)) begin
+            $error("Not enough bits transmitted (case 0)");
+        end else begin
+            $display("Number of bits transmitted is OK (case 0)");
+        end
+
+        if (!(err_bits_0 == 0)) begin
+            $error("Bit error detected (case 0)");
+        end else begin
+            $display("No bit errors detected (case 0)");
+        end
 
         if (!(total_bits_1 >= 9500)) begin
             $error("Not enough bits transmitted (case 1)");

--- a/vlog/new_tb/channel_simple.sv
+++ b/vlog/new_tb/channel_simple.sv
@@ -12,7 +12,7 @@ module channel_simple #(
 	output pwl out
 );
     // calculate angular frequency
-    localparam real omega = (tau != -1) ? (1.0/tau) : (1.0/(rel_speed*baud_rate));
+    localparam real omega = (tau != -1) ? (1.0/tau) : (rel_speed*baud_rate);
 
     // convert to Hz
 	localparam real fp = omega/(2.0*3.141592653589793);

--- a/vlog/new_tb/channel_simple.sv
+++ b/vlog/new_tb/channel_simple.sv
@@ -5,16 +5,17 @@
 module channel_simple #(
 	parameter real etol = 0.001,		// error tolerance of PWL approximation
 	parameter real baud_rate = 16e9,	// communication baud rate
-	parameter real rel_speed = 1 		// higher number is faster
+	parameter real rel_speed = 1, 		// higher number is faster
+	parameter real tau = -1
 ) (
 	input pwl in,
 	output pwl out
 );
+    // calculate angular frequency
+    localparam real omega = (tau != -1) ? (1.0/tau) : (1.0/(rel_speed*baud_rate));
 
-	localparam real tau = 1.0/(rel_speed*baud_rate);
-
-	localparam real M_PI = 3.141592653589793;
-	localparam real fp = 1.0/(2.0*M_PI*tau);
+    // convert to Hz
+	localparam real fp = omega/(2.0*3.141592653589793);
 
 	pwl_filter_real_p1 #(
 		.etol(etol),

--- a/vlog/new_tb/diff_channel.sv
+++ b/vlog/new_tb/diff_channel.sv
@@ -3,7 +3,8 @@
 `default_nettype none
 
 module diff_channel #(
-	parameter channel_type = "simple"
+	parameter channel_type = "simple",
+	parameter real tau = -1
 ) (
 	input pwl in_p,
 	input pwl in_n,
@@ -13,11 +14,15 @@ module diff_channel #(
 
 	generate
 	if (channel_type == "simple") begin
-		channel_simple channel_p (
+		channel_simple #(
+		    .tau(tau)
+		) channel_p (
 			.in(in_p),
 			.out(out_p)
 		);
-		channel_simple channel_n (
+		channel_simple #(
+		    .tau(tau)
+		) channel_n (
 			.in(in_n),
 			.out(out_n)
 		);


### PR DESCRIPTION
(This PR only modifies testing-related files)

## Summary
1. The ``MM_CDR`` test is now part of the regression and passes.
2. The ``PRBS`` test now exercises both the built-in self test (internal PRBS generator) and the data path coming from the ADC.
3. Workarounds that were previously needed for the ``AC`` and ``LOOPBACK_RETIMER`` are removed.
4. JTAG-related I/O for all tests now exercises a path that was previously not covered (wiring from the raw JTAG interface to the various block-specific interfaces).
5. The ``GLITCH`` test now sweeps PI codes for each PI independently, and starts each PI at a realistic phase offset.

## Details
1. To get the ``MM_CDR`` test passing, I did a number of things:
    1.  Set up the test so that it sends PRBS data through a channel model while looking for errors using the on-chip PRBS checker.
    2. Set the bandwidth of the channel model so that FFE post-processing was not needed (and yet kept the bandwidth low enough that there is sufficient ISI for the baud-rate phase detector)
    3. Increased ``Kp`` from ``2`` to ``18``.  This effectively increased the loop bandwidth from ~150 Hz to ~10 MHz.  For reference, the loop stops working at ``Kp=20``.  Note that ``Kp`` is the coefficient for the integral of phase error.
    4. Disabled ``en_freq_est``.  (If we can run at a bandwidth of a few MHz, that should be fast enough to track spread-spectrum modulation occurring at ~30 kHz).