### PR TITLE
Add higher-performance emulation models

### DIFF
--- a/config/fpga/analog_slice_cfg.yml
+++ b/config/fpga/analog_slice_cfg.yml
@@ -1,0 +1,13 @@
+dt: 0.1e-6
+func_order: 1
+func_numel: 512
+chunk_width: 8
+num_chunks: 4
+slices_per_bank: 4
+num_banks: 4
+pi_ctl_width: 9
+vref_rx: 0.4
+vref_tx: 0.4
+n_adc: 8
+freq_tx: 16.0e+9
+freq_rx: 4.0e+9

--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,10 @@ def pytest_addoption(parser):
         '--prbs_test_dur', default=10.0, type=float, help='Length of time of the PRBS emulation test.'
     )
 
+    parser.addoption(
+        '--fpga_sim_ctrl', default='UART_ZYNQ', type=str, help='Emulation control style (UART or VIO)'
+    )
+
 @pytest.fixture
 def dump_waveforms(request):
     return request.config.getoption('--dump_waveforms')
@@ -56,3 +60,7 @@ def emu_clk_freq(request):
 @pytest.fixture
 def prbs_test_dur(request):
     return request.config.getoption('--prbs_test_dur')
+
+@pytest.fixture
+def fpga_sim_ctrl(request):
+    return request.config.getoption('--fpga_sim_ctrl')

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,10 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        '--simulator_name', default=None, type=str, help='Name of the simulator to use.'
+    )
+
+    parser.addoption(
         '--board_name', default='ZC702', type=str, help='Name of the FPGA board.'
     )
 
@@ -28,6 +32,10 @@ def pytest_addoption(parser):
 @pytest.fixture
 def dump_waveforms(request):
     return request.config.getoption('--dump_waveforms')
+
+@pytest.fixture
+def simulator_name(request):
+    return request.config.getoption('--simulator_name')
 
 @pytest.fixture
 def board_name(request):

--- a/dragonphy/adapt_fir.py
+++ b/dragonphy/adapt_fir.py
@@ -17,7 +17,7 @@ class AdaptFir:
             tau=25e-12,
             t_delay=31.25e-12,
             sampl_rate=160e9,
-            resp_depth=500
+            resp_depth=512
         )
         chan = Channel(**kwargs)
 

--- a/dragonphy/anasymod.py
+++ b/dragonphy/anasymod.py
@@ -3,6 +3,10 @@ import yaml
 
 class AnasymodProjectConfig:
     def __init__(self, fpga_sim_ctrl='UART_ZYNQ'):
+        # validate input
+        assert fpga_sim_ctrl in {'UART_ZYNQ', 'VIVADO_VIO'}, 'Invalid setting.'
+
+        # initialize the config dictionary
         self.config = {
             'PROJECT': {
                 'dt': 50e-9,

--- a/dragonphy/anasymod.py
+++ b/dragonphy/anasymod.py
@@ -11,7 +11,7 @@ class AnasymodProjectConfig:
                 'emu_clk_freq': 5e6,
                 'cpu_debug_mode': 0,
                 'cpu_debug_hierarchies': [],
-                'flatten_hierarchy': 'none'
+                'flatten_hierarchy': 'rebuilt'
             },
             'FPGA_TARGET': {
                 'fpga': {

--- a/dragonphy/fpga_models/analog_slice.py
+++ b/dragonphy/fpga_models/analog_slice.py
@@ -58,7 +58,7 @@ class AnalogSlice:
         # create a function
         domain = [chan.t_vec[0], chan.t_vec[-1]]
         chan_func = m.make_function(chan.interp, domain=domain, order=system_values['func_order'],
-                                    numel=system_values['func_numel'], verif_per_seg=10)
+                                    numel=system_values['func_numel'])
         self.check_func_error(chan_func)
 
         # compute weights to apply to pulse responses
@@ -70,7 +70,8 @@ class AnalogSlice:
                     range_=system_values['vref_tx']
                 )
             )
-            m.set_next_cycle(weights[-1], if_(m.chunk[k], system_values['vref_tx'], -system_values['vref_tx']))
+            m.set_next_cycle(weights[-1], if_(m.chunk[k], system_values['vref_tx'], -system_values['vref_tx']),
+                             clk=m.clk, rst=m.rst)
 
         # Compute the evaluation time for this slice
         t_samp = m.bind_name(
@@ -153,8 +154,8 @@ class AnalogSlice:
         samp = np.random.uniform(f.domain[0], f.domain[1], 1000)
         approx = f.eval_on(samp)
         exact = f.func(samp)
-        err = np.sqrt(np.mean((exact-approx)**2))
-        print(f'RMS error: {err}')
+        err = np.max(np.abs(exact-approx))
+        print(f'Worst-case error: {err}')
 
     @staticmethod
     def required_values():

--- a/dragonphy/fpga_models/analog_slice.py
+++ b/dragonphy/fpga_models/analog_slice.py
@@ -1,0 +1,163 @@
+# Generic imports
+from pathlib import Path
+from math import log2, ceil
+import numpy as np
+
+# FPGA-specific imports
+from msdsl import MixedSignalModel, VerilogGenerator, sum_op, clamp_op, to_uint, to_sint
+from msdsl.expr.extras import if_
+from msdsl.expr.format import SIntFormat
+
+# DragonPHY imports
+from dragonphy import Filter, get_file
+
+class AnalogSlice:
+    def __init__(self, filename=None, **system_values):
+        # set a fixed random seed for repeatability
+        np.random.seed(0)
+
+        module_name = Path(filename).stem
+        build_dir   = Path(filename).parent
+
+        #This is a wonky way of validating this.. :(
+        assert (all([req_val in system_values for req_val in self.required_values()])), \
+            f'Cannot build {module_name}, Missing parameter in config file'
+
+        m = MixedSignalModel(module_name, dt=system_values['dt'], build_dir=build_dir)
+
+        # Chunk of bits from the history; corresponding delay is bit_idx/freq_tx delay
+        m.add_digital_input('chunk', width=system_values['chunk_width'])
+        m.add_digital_input('chunk_idx', width=int(ceil(log2(system_values['num_chunks']))))
+
+        # Control code for the corresponding PI slice
+        m.add_digital_input('pi_ctl', width=system_values['pi_ctl_width'])
+
+        # Indicates sequencing of ADC slice within a bank (typically a static value)
+        m.add_digital_input('slice_offset', width=int(ceil(log2(system_values['slices_per_bank']))))
+
+        # Control codes that affect states in the slice
+        m.add_digital_input('sample_ctl')
+        m.add_digital_input('incr_sum')
+        m.add_digital_input('write_output')
+
+        # ADC sign and magnitude
+        m.add_digital_output('out_sgn')
+        m.add_digital_output('out_mag', width=system_values['n_adc'])
+
+        # Emulator clock and reset
+        m.add_digital_input('clk')
+        m.add_digital_input('rst')
+
+        # Sample the pi_ctl code
+        m.add_digital_state('pi_ctl_sample', width=system_values['pi_ctl_width'])
+        m.set_next_cycle(m.pi_ctl_sample, m.pi_ctl, clk=m.clk, rst=m.rst, ce=m.sample_ctl)
+
+        # read in the channel data
+        chan = Filter.from_file(get_file('build/chip_src/adapt_fir/chan.npy'))
+
+        # create a function
+        domain = [chan.t_vec[0], chan.t_vec[-1]]
+        chan_func = m.make_function(chan.interp, domain=domain, order=system_values['func_order'],
+                                    numel=system_values['func_numel'], verif_per_seg=10)
+        self.check_func_error(chan_func)
+
+        # compute weights to apply to pulse responses
+        weights = []
+        for k in range(system_values['chunk_width']):
+            weights.append(
+                m.add_analog_state(
+                    f'weights_{k}',
+                    range_=system_values['vref_tx']
+                )
+            )
+            m.set_next_cycle(weights[-1], if_(m.chunk[k], system_values['vref_tx'], -system_values['vref_tx']))
+
+        # Compute the evaluation time for this slice
+        t_samp = m.bind_name(
+            't_samp',
+            ((m.slice_offset*(1<<system_values['pi_ctl_width'])) + m.pi_ctl_sample)
+            / ((2.0**system_values['pi_ctl_width'])*system_values['freq_rx'])
+        )
+
+        # Evaluate the step response function.  Note that the number of evaluation times is the
+        # number of chunks plus one.
+        f_eval = []
+        for k in range(system_values['chunk_width']+1):
+            # compute change time as an integer multiple of the TX period
+            chg_idx = m.bind_name(
+                f'chg_idx_{k}', (
+                    system_values['slices_per_bank']*system_values['num_banks']
+                    - (m.chunk_idx+1)*system_values['chunk_width']
+                    + k
+                )
+            )
+
+            # scale by TX period
+            t_chg = m.bind_name(f't_chg_{k}', chg_idx/system_values['freq_tx'])
+
+            # compute the kth evaluation time
+            t_eval = m.bind_name(f't_eval_{k}', t_samp - t_chg)
+
+            # evaluate the function
+            f_eval.append(m.set_from_sync_func(f'f_eval_{k}', chan_func, t_eval, clk=m.clk, rst=m.rst))
+
+        # Compute the pulse responses for each bit
+        pulse_resp = []
+        for k in range(system_values['chunk_width']):
+            pulse_resp.append(
+                m.bind_name(
+                    f'pulse_resp_{k}',
+                    weights[k]*(f_eval[k] - f_eval[k+1])
+                )
+            )
+
+        # sum up all of the pulse responses
+        pulse_resp_sum = m.bind_name('pulse_resp_sum', sum_op(pulse_resp))
+
+        # update the overall sample value
+        sample_value = m.add_analog_state('analog_sample', range_=5*system_values['vref_rx'])
+        m.set_next_cycle(
+            sample_value,
+            if_(m.incr_sum, sample_value + pulse_resp_sum, pulse_resp_sum),
+            clk=m.clk,
+            rst=m.rst
+        )
+
+        # determine out_sgn (note that the definition is opposite of the typical
+        # meaning; "0" means negative)
+        out_sgn = if_(sample_value < 0, 0, 1)
+        m.set_next_cycle(m.out_sgn, out_sgn, clk=m.clk, rst=m.rst, ce=m.write_output)
+
+        # determine out_mag
+        vref_rx, n_adc = system_values['vref_rx'], system_values['n_adc']
+        abs_val = m.bind_name('abs_val', if_(sample_value < 0, -1.0*sample_value, sample_value))
+        code_real_unclamped = m.bind_name('code_real_unclamped', (abs_val / vref_rx) * ((2**(n_adc-1))-1))
+        code_real = m.bind_name('code_real', clamp_op(code_real_unclamped, 0, (2**(n_adc-1))-1))
+
+        # TODO: clean this up -- since real ranges are not intervals, we need to tell MSDSL
+        # that the range of the signed integer is smaller
+        code_sint = to_sint(code_real, width=n_adc+1)
+        code_sint.format_ = SIntFormat(width=n_adc+1, min_val=0, max_val=(2**(n_adc-1))-1)
+        code_sint = m.bind_name('code_sint', code_sint)
+
+        code_uint = m.bind_name('code_uint', to_uint(code_sint, width=n_adc))
+        m.set_next_cycle(m.out_mag, code_uint, clk=m.clk, rst=m.rst, ce=m.write_output)
+
+        # generate the model
+        m.compile_to_file(VerilogGenerator())
+
+        self.generated_files = [filename]
+
+    @staticmethod
+    def check_func_error(f):
+        samp = np.random.uniform(f.domain[0], f.domain[1], 1000)
+        approx = f.eval_on(samp)
+        exact = f.func(samp)
+        err = np.sqrt(np.mean((exact-approx)**2))
+        print(f'RMS error: {err}')
+
+    @staticmethod
+    def required_values():
+        return ['dt', 'func_order', 'func_numel', 'chunk_width', 'num_chunks',
+                'slices_per_bank', 'num_banks', 'pi_ctl_width', 'vref_rx',
+                'vref_tx', 'n_adc', 'freq_tx', 'freq_rx']

--- a/dragonphy/fpga_models/chan_core.py
+++ b/dragonphy/fpga_models/chan_core.py
@@ -38,7 +38,7 @@ class ChannelCore:
         # create a function
         domain = [chan.t_vec[0], chan.t_vec[-1]]
         chan_func = m.make_function(chan.interp, domain=domain, order=system_values['func_order'],
-                                    numel=system_values['func_numel'], verif_per_seg=10)
+                                    numel=system_values['func_numel'])
         self.check_func_error(chan_func)
 
         # create a history of past inputs

--- a/dragonphy/views.py
+++ b/dragonphy/views.py
@@ -202,9 +202,12 @@ def get_deps_cpu_sim(cell_name=None, impl_file=None, override=None):
 
     return deps
 
-def get_deps_fpga_emu(cell_name=None, impl_file=None):
-    deps = []
+def get_deps_fpga_emu(cell_name=None, impl_file=None, override=None):
+    # set defaults
+    if override is None:
+        override = {}
 
+    deps = []
     deps += get_deps(
         cell_name=cell_name,
         impl_file=impl_file,
@@ -218,7 +221,8 @@ def get_deps_fpga_emu(cell_name=None, impl_file=None):
         skip={'svreal', 'assign_real', 'comp_real', 'add_sub_real', 'ite_real',
               'dff_real', 'mul_real', 'mem_digital', 'sync_rom_real', 'DW_tap'},
         no_descend={'chan_core', 'tx_core', 'osc_model_core', 'clk_delay_core',
-                    'rx_adc_core', 'analog_slice'}
+                    'rx_adc_core', 'analog_slice'},
+        override=override
     )
 
     return deps

--- a/dragonphy/views.py
+++ b/dragonphy/views.py
@@ -218,7 +218,7 @@ def get_deps_fpga_emu(cell_name=None, impl_file=None):
         skip={'svreal', 'assign_real', 'comp_real', 'add_sub_real', 'ite_real',
               'dff_real', 'mul_real', 'mem_digital', 'sync_rom_real', 'DW_tap'},
         no_descend={'chan_core', 'tx_core', 'osc_model_core', 'clk_delay_core',
-                    'rx_adc_core'}
+                    'rx_adc_core', 'analog_slice'}
     )
 
     return deps

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -64,3 +64,24 @@ July 7, 2020
   * BRAM: 42.5 / 545
   * Build time: 36m13.436s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+
+July 8, 2020
+* Emulation with 16x channels on ZC706, using a macro model for analog_core that computes all of the ADC samples in parallel.  This measurement used a history length of 32 bits, processed over 4 cycles in chunks of size 8.  For this experiment, "flatten_hierarchy" was set to "rebuilt" (default from Vivado).  The fpga_sim_ctrl option used here was "VIVADO_VIO", for comparison with "UART_ZYNQ"
+  * Command: ``time pytest tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 30e6 --prbs_test_dur 30 --fpga_sim_ctrl VIVADO_VIO``
+  * PRBS test took  seconds.
+  * Total bits: 
+  *  Mb/s
+  * Slice LUTs: 88383 / 218600
+    * analog_core: 35754
+    * digital_core: 40170
+  * Slice Registers: 24737 / 437200
+    * analog_core: 3043
+    * digital_core: 17796
+  * Slice: 28508 / 54650
+    * analog_core: 11354
+    * digital_core: 15004
+  * DSP: 720 / 900
+  * BRAM: 42.5 / 545
+  * Build time: 37m31.047s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -24,7 +24,7 @@ Jun 24, 2020
     * /proc/cpuinfo did not display the real CPU information since r7cad-generic is a VM
 
 July 6, 2020
-* Emulation with 16x channels on ZC706, using a macro model for analog_core that computes all of the ADC samples in parallel.  This measurement used a history length of 32 bits, processed over 4 cycles in chunks of size 8.
+* Emulation with 16x channels on ZC706, using a macro model for analog_core that computes all of the ADC samples in parallel.  This measurement used a history length of 32 bits, processed over 4 cycles in chunks of size 8.  For this experiment, "flatten_hierarchy" was set to "none" since this had solved a synthesis issue in the previous emulation architecture.  However, this may have caused the resource utilization to be high.
   * Command: ``time pytest tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_6 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 20e6 --prbs_test_dur 30``
   * PRBS test took 30.072776794433594 seconds.
   * Total bits: 1602767056
@@ -43,4 +43,24 @@ July 6, 2020
   * BRAM: 42.5 / 545
     * Interesting to note that each analog slice uses about 27 LUTs and 17 FF for each sync_rom_real.  Each slice has 18 ROMs, so that accounts for 7.8k LUTs and 4.9k FFs.
   * Build time: 38m17.143s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+
+July 7, 2020
+* Emulation with 16x channels on ZC706, using a macro model for analog_core that computes all of the ADC samples in parallel.  This measurement used a history length of 32 bits, processed over 4 cycles in chunks of size 8.  For this experiment, "flatten_hierarchy" was set to "rebuilt" (default from Vivado)
+  * Command: ``time pytest tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_6 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 30e6 --prbs_test_dur 30``
+  * PRBS test took 30.072660207748413 seconds.
+  * Total bits: 2404040576
+  * 79.94 Mb/s
+  * Slice LUTs: 88561 / 218600
+    * analog_core: 35756 
+    * digital_core: 40118
+  * Slice Registers: 25225 / 437200
+    * analog_core: 3043
+    * digital_core: 17797
+  * Slice: 27900 / 54650
+    * analog_core: 
+    * digital_core: 
+  * DSP: 720 / 900
+  * BRAM: 42.5 / 545
+  * Build time: 36m13.436s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -16,9 +16,31 @@ Jun 24, 2020
   * BRAM: 42.5 / 545
   * Build time: 30m 35.161s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
-* Simulation with 16x channels:
+* Simulation with 16x channels (using Xcelium)
   * PRBS test took 42.509094 seconds.
   * Total_bits: 608192
   * Throughput: 14.3 kb/s
   * r7cad-generic processor, CentOS Linux release 7.7.1908 (Core), 128 GB RAM
     * /proc/cpuinfo did not display the real CPU information since r7cad-generic is a VM
+
+July 6, 2020
+* Emulation with 16x channels on ZC706, using a macro model for analog_core that computes all of the ADC samples in parallel.  This measurement used a history length of 32 bits, processed over 4 cycles in chunks of size 8.
+  * Command: ``time pytest tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_6 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 20e6 --prbs_test_dur 30``
+  * PRBS test took 30.072776794433594 seconds.
+  * Total bits: 1602767056
+  * 53.30 Mb/s
+  * Slice LUTs: 99149 / 218600
+    * analog_core: 48741 
+    * digital_core: 47508
+  * Slice Registers: 30487 / 437200
+    * analog_core: 8132
+    * digital_core: 17617
+  * Slice: 32971 / 54650
+    * analog_core: 16475
+    * digital_core: 15730
+  * DSP: 652 / 900
+    * Each slice is using about 40-43 DSP blocks.  All 652 DSPs are used in the analog_slice instances.  
+  * BRAM: 42.5 / 545
+    * Interesting to note that each analog slice uses about 27 LUTs and 17 FF for each sync_rom_real.  Each slice has 18 ROMs, so that accounts for 7.8k LUTs and 4.9k FFs.
+  * Build time: 38m17.143s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`

--- a/experiments/jtag_comparison/results.md
+++ b/experiments/jtag_comparison/results.md
@@ -1,0 +1,12 @@
+* JTAG test 1: bit_bang=False, uart=True, jtag_sleep_us=1, use_batch_mode=False, print_mode='test', cdr_settling_time=0.1, prbs_test_dur=0.1
+  * Test time: 6.9896769523620605 seconds
+  * UART bytes transmitted: 39690 
+* JTAG test 2: bit_bang=False, uart=True, jtag_sleep_us=1, use_batch_mode=True, print_mode='test', cdr_settling_time=0.1, prbs_test_dur=0.1
+  * Test time: 4.185762166976929 seconds
+  * UART bytes transmitted: 39690
+* JTAG test 3: bit_bang=True, uart=True, jtag_sleep_us=1, use_batch_mode=False, print_mode='debug', cdr_settling_time=0.1, prbs_test_dur=0.1
+  * Test time: 237.75752425193787 seconds
+  * UART bytes transmitted: 2416386
+* JTAG test 4: bit_bang=True, uart=True, jtag_sleep_us=1, use_batch_mode=True, print_mode='debug', cdr_settling_time=0.1, prbs_test_dur=0.1
+  * Test time: 211.79461526870728 seconds
+  * UART bytes transmitted: 2416386

--- a/experiments/jtag_comparison/results.md
+++ b/experiments/jtag_comparison/results.md
@@ -1,3 +1,4 @@
+## July 7, 2020
 * JTAG test 1: bit_bang=False, uart=True, jtag_sleep_us=1, use_batch_mode=False, print_mode='test', cdr_settling_time=0.1, prbs_test_dur=0.1
   * Test time: 6.9896769523620605 seconds
   * UART bytes transmitted: 39690 
@@ -10,3 +11,17 @@
 * JTAG test 4: bit_bang=True, uart=True, jtag_sleep_us=1, use_batch_mode=True, print_mode='debug', cdr_settling_time=0.1, prbs_test_dur=0.1
   * Test time: 211.79461526870728 seconds
   * UART bytes transmitted: 2416386
+
+## July 8, 2020
+* Trial 1:
+  * JtagTester(comm_style='vio', bit_bang=True, use_ffe=True, print_mode='debug')
+  * Register writes: 41
+  * Register reads: 4
+  * Test took 1573.117070198059 seconds.
+* Trial 2:
+  * t = JtagTester(comm_style='vio', bit_bang=True, use_ffe=True, print_mode='debug')
+  * Register writes: 697
+  * Register reads: 4
+  * Test took 23908.544766187668 seconds.
+
+

--- a/experiments/jtag_comparison/results.md
+++ b/experiments/jtag_comparison/results.md
@@ -23,5 +23,34 @@
   * Register writes: 697
   * Register reads: 4
   * Test took 23908.544766187668 seconds.
+  
+## July 9, 2020
+* Trial 1:
+  * JtagTester(use_batch_mode=False, bit_bang=False, print_mode='test')
+  * Register writes: 697
+  * Register reads: 4
+  * Test took 3.76419997215271 seconds.
+  * Total bytes transmitted (UART): 41789
+* Trial 2:
+  * JtagTester(use_batch_mode=True, bit_bang=False, print_mode='test')
+  * Register writes: 697
+  * Register reads: 4
+  * Test took 3.7579543590545654 seconds.
+  * Total bytes transmitted (UART): 41789
+* Trial 3:
+  * JtagTester(use_batch_mode=False, bit_bang=True, print_mode='debug')
+  * Test took 186.3524034023285 seconds.
+  * Register writes: 697
+  * Register reads: 4
+  * Total bytes transmitted (UART): 2148226
+* Trial 4:
+  * JtagTester(use_batch_mode=True, bit_bang=True, print_mode='debug')
+  * Test took 186.54292559623718 seconds.
+  * Register writes: 697
+  * Register reads: 4
+  * Total bytes transmitted (UART): 2148226
+
+
+
 
 

--- a/experiments/jtag_comparison/test_jtag.py
+++ b/experiments/jtag_comparison/test_jtag.py
@@ -1,0 +1,585 @@
+import serial
+import time
+import json
+import re
+from pathlib import Path
+from math import exp, ceil, log2
+
+from dragonphy import *
+
+THIS_DIR = Path(__file__).resolve().parent
+
+class DeferredExpr:
+    def __invert__(self):
+        return DeferredUnaryOp(lambda a: ~a, self)
+
+    def __neg__(self):
+        return DeferredUnaryOp(lambda a: -a, self)
+
+    def __add__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a + b, self, other)
+
+    def __sub__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a - b, self, other)
+
+    def __mul__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a * b, self, other)
+
+    def __lshift__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a << b, self, other)
+
+    def __rshift__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a >> b, self, other)
+
+    def __or__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a | b, self, other)
+    __ror__= __or__
+
+    def __and__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a & b, self, other)
+
+    def __xor__(self, other):
+        if not isinstance(other, DeferredExpr):
+            other = DeferredValue(other)
+        return DeferredBinaryOp(lambda a, b: a ^ b, self, other)
+
+class DeferredUnaryOp(DeferredExpr):
+    def __init__(self, op, data):
+        self.op = op
+        self.data = data
+
+    @property
+    def value(self):
+        return self.op(self.data.value)
+
+class DeferredBinaryOp(DeferredExpr):
+    def __init__(self, op, lhs, rhs):
+        self.op = op
+        self.lhs = lhs
+        self.rhs = rhs
+
+    @property
+    def value(self):
+        return self.op(self.lhs.value, self.rhs.value)
+
+class DeferredValue(DeferredExpr):
+    def __init__(self, value=None):
+        self.value = value
+
+class JtagTester:
+    def __init__(self, ser_port='/dev/ttyUSB0', ffe_length=10, bit_bang=False, uart=True,
+                 jtag_sleep_us=1, use_batch_mode=False, print_mode='debug',
+                 cdr_settling_time=0.1, prbs_test_dur=0.1):
+        # save settings
+        self.ser_port = ser_port
+        self.bit_bang = bit_bang
+        self.uart = uart
+        self.ffe_length = ffe_length
+        self.jtag_sleep_us = jtag_sleep_us
+        self.use_batch_mode = use_batch_mode
+        self.print_mode = print_mode
+        self.cdr_settling_time = cdr_settling_time
+        self.prbs_test_dur = prbs_test_dur
+
+        # initialize
+
+        self.jtag_inst_width = 5
+        self.sc_bus_width = 32
+        self.sc_addr_width = 14
+
+        self.tc_bus_width = 32
+        self.tc_addr_width = 14
+
+        self.sc_op_width = 2
+        self.tc_op_width = 2
+
+        self.sc_cfg_data = 8
+        self.sc_cfg_inst = 9
+        self.sc_cfg_addr = 10
+        self.tc_cfg_data = 12
+        self.tc_cfg_inst = 13
+        self.tc_cfg_addr = 14
+
+        self.read = 1
+        self.write = 2
+
+        # build register dictionary
+        reg_list = json.load(open(get_file('build/all/jtag/reg_list.json'), 'r'))
+        self.reg_dict = {elem['name']: elem['addresses'] for elem in reg_list}
+
+        # pattern for decoding array addresses
+        self.arr_pat = re.compile(r'([a-zA-Z_0-9]+)+\[(\d+)\]')
+
+        # list of transactions queued up
+        self.batch_started = False
+        self.uart_batch = []
+        self.uart_bytes_total = 0
+
+        # connect UART if desired
+        if self.uart:
+            self.connect_serial()
+
+    def start_batch(self):
+        self.batch_started = True
+        self.uart_batch = []
+
+    def run_batch(self):
+        # write all commands as a block
+        all_cmds = [f'{cmd}\n' for cmd, _ in self.uart_batch]
+        all_cmds = ''.join(all_cmds).encode('utf-8')
+        self.ser.write(all_cmds)
+
+        # keep track of how many bits were sent
+        self.uart_bytes_total += len(all_cmds)
+
+        # extract all of the deferred values
+        for _, deferred_value in self.uart_batch:
+            if deferred_value is not None:
+                deferred_value.value = int(self.ser.readline().strip())
+
+        # clear the batch flag
+        self.batch_started = False
+
+    def get_reg_addr(self, name):
+        m = self.arr_pat.match(name)
+        if m:
+            name = m.groups()[0]
+            index = int(m.groups()[1])
+            return self.reg_dict[name][index]
+        else:
+            return self.reg_dict[name]
+
+    def connect_serial(self):
+        # connect to the CPU
+        print('Connecting to the CPU...')
+        self.ser = serial.Serial(
+            port=self.ser_port,
+            baudrate=115200
+        )
+
+    # run a serial command
+    def ser_cmd(self, cmd, expect_output=False):
+        if self.batch_started:
+            if expect_output:
+                deferred_value = DeferredValue()
+                self.uart_batch.append((cmd, deferred_value))
+                return deferred_value
+            else:
+                self.uart_batch.append((cmd, None))
+        else:
+            # send the command
+            cmd_bytes = f'{cmd}\n'.encode('utf-8')
+            self.ser.write(cmd_bytes)
+
+            # keep track of how many bytes have been sent
+            self.uart_bytes_total += len(cmd_bytes)
+
+            # read output if needed
+            if expect_output:
+                return int(self.ser.readline().strip())
+
+    # functions
+    def do_reset(self):
+        if self.uart:
+            if self.bit_bang:
+                # initialize JTAG signals
+                self.set_tdi(0)
+                self.set_tck(0)
+                self.set_tms(1)
+                self.set_trst_n(0)
+                self.cycle_tck()
+
+                # de-assert reset
+                self.set_trst_n(1)
+                self.cycle_tck()
+
+                # go to the IDLE state
+                self.set_tms(1)
+                self.cycle_tck()
+                for _ in range(10):
+                    self.cycle_tck()
+
+                self.set_tms(0)
+                self.cycle_tck()
+            else:
+                self.ser_cmd('RESET')
+
+    def do_init(self):
+        if self.uart:
+            self.ser_cmd('INIT')
+
+    def cycle_tck(self):
+        self.set_tck(1)
+        self.set_tck(0)
+
+    def set_emu_rst(self, val):
+        if self.uart:
+            self.ser_cmd(f'SET_EMU_RST {val}')
+
+    def set_rstb(self, val):
+        if self.uart:
+            self.ser_cmd(f'SET_RSTB {val}')
+
+    def set_sleep(self, val):
+        if self.uart:
+            self.ser_cmd(f'SET_SLEEP {val}')
+
+    def set_tdi(self, val):
+        if self.uart:
+            self.ser_cmd(f'SET_TDI {val}')
+
+    def set_tck(self, val):
+        if self.uart:
+            self.ser_cmd(f'SET_TCK {val}')
+
+    def set_tms(self, val):
+        if self.uart:
+            self.ser_cmd(f'SET_TMS {val}')
+
+    def set_trst_n(self, val):
+        if self.uart:
+            self.ser_cmd(f'SET_TRST_N {val}')
+
+    def get_tdo(self):
+        if self.uart:
+            return self.ser_cmd(f'GET_TDO', expect_output=True)
+
+    def shift_ir(self, val, width):
+        if self.uart:
+            if self.bit_bang:
+                # Move to Select-DR-Scan state
+                self.set_tms(1)
+                self.cycle_tck()
+                
+                # Move to Select-IR-Scan state
+                self.set_tms(1)
+                self.cycle_tck()
+
+                # Move to Capture IR state
+                self.set_tms(0)
+                self.cycle_tck()
+                
+                # Move to Shift-IR state
+                self.set_tms(0)
+                self.cycle_tck()
+                
+                # Remain in Shift-IR state and shift in inst_in.
+                # Observe the TDO signal to read the x_inst_out
+                for i in range(width-1):
+                    self.set_tdi((val >> i) & 1)
+                    self.cycle_tck()
+                
+                # Shift in the last bit and switch to Exit1-IR state
+                self.set_tdi((val >> (width - 1)) & 1)
+                self.set_tms(1)
+                self.cycle_tck()
+                
+                # Move to Update-IR state
+                self.set_tms(1)
+                self.cycle_tck()
+                
+                # Move to Run-Test/Idle state
+                self.set_tms(0)
+                self.cycle_tck()
+                self.cycle_tck()
+            else:
+                self.ser_cmd(f'SIR {val} {width}')
+
+    def shift_dr(self, val, width):
+        if self.uart:
+            if self.bit_bang:
+                # Move to Select-DR-Scan state
+                self.set_tms(1)
+                self.cycle_tck()
+
+                # Move to Capture-DR state
+                self.set_tms(0)
+                self.cycle_tck()
+
+                # Move to Shift-DR state
+                self.set_tms(0)
+                self.cycle_tck()
+
+                # Remain in Shift-DR state and shift in data_in.
+                # Observe the TDO signal to read the data_out
+                retval = 0
+                for i in range(width-1):
+                    self.set_tdi((val >> i) & 1)
+                    retval |= (self.get_tdo() << i)
+                    self.cycle_tck()
+
+                # Shift in the last bit and switch to Exit1-DR state
+                self.set_tdi((val >> (width - 1)) & 1)
+                retval |= (self.get_tdo() << (width-1))
+                self.set_tms(1)
+                self.cycle_tck()
+
+                # Move to Update-DR state
+                self.set_tms(1)
+                self.cycle_tck()
+
+                # Move to Run-Test/Idle state
+                self.set_tms(0)
+                self.cycle_tck()
+                self.cycle_tck()
+
+                # Return result
+                return retval
+            else:
+                return self.ser_cmd(f'SDR {val} {width}', expect_output=True)
+
+    def write_tc_reg(self, name, val):
+        # specify address
+        self.shift_ir(self.tc_cfg_addr, self.jtag_inst_width)
+        self.shift_dr(self.get_reg_addr(name), self.tc_addr_width)
+
+        # send data
+        self.shift_ir(self.tc_cfg_data, self.jtag_inst_width)
+        self.shift_dr(val, self.tc_bus_width)
+
+        # specify "WRITE" operation
+        self.shift_ir(self.tc_cfg_inst, self.jtag_inst_width)
+        self.shift_dr(self.write, self.tc_op_width)
+
+    def write_sc_reg(self, name, val):
+        # specify address
+        self.shift_ir(self.sc_cfg_addr, self.jtag_inst_width)
+        self.shift_dr(self.get_reg_addr(name), self.sc_addr_width)
+
+        # send data
+        self.shift_ir(self.sc_cfg_data, self.jtag_inst_width)
+        self.shift_dr(val, self.sc_bus_width)
+
+        # specify "WRITE" operation
+        self.shift_ir(self.sc_cfg_inst, self.jtag_inst_width)
+        self.shift_dr(self.write, self.sc_op_width)
+
+    def read_tc_reg(self, name):
+        # specify address
+        self.shift_ir(self.tc_cfg_addr, self.jtag_inst_width)
+        self.shift_dr(self.get_reg_addr(name), self.tc_addr_width)
+
+        # specify "READ" operation
+        self.shift_ir(self.tc_cfg_inst, self.jtag_inst_width)
+        self.shift_dr(self.read, self.tc_op_width)
+
+        # get data
+        self.shift_ir(self.tc_cfg_data, self.jtag_inst_width)
+        return self.shift_dr(0, self.tc_bus_width)
+
+    def read_sc_reg(self, name):
+        # specify address
+        self.shift_ir(self.sc_cfg_addr, self.jtag_inst_width)
+        self.shift_dr(self.get_reg_addr(name), self.sc_addr_width)
+
+        # specify "READ" operation
+        self.shift_ir(self.sc_cfg_inst, self.jtag_inst_width)
+        self.shift_dr(self.read, self.sc_op_width)
+
+        # get data
+        self.shift_ir(self.sc_cfg_data, self.jtag_inst_width)
+        return self.shift_dr(0, self.sc_bus_width)
+
+    def load_weight(
+        self,
+        d_idx, # clog2(ffe_length)
+        w_idx, # 4 bits
+        value, # 10 bits
+    ):
+        self.print(f'Loading weight d_idx={d_idx}, w_idx={w_idx} with value {value}')
+
+        # determine number of bits for d_idx
+        d_idx_bits = int(ceil(log2(self.ffe_length)))
+
+        # write wme_ffe_inst
+        wme_ffe_inst = 0
+        wme_ffe_inst |= d_idx & ((1<<d_idx_bits)-1)
+        wme_ffe_inst |= (w_idx & 0b1111) << d_idx_bits
+        self.write_tc_reg('wme_ffe_inst', wme_ffe_inst)
+
+        # write wme_ffe_data
+        wme_ffe_data = value & 0b1111111111
+        self.write_tc_reg('wme_ffe_data', wme_ffe_data)
+
+        # pulse wme_ffe_exec
+        self.write_tc_reg('wme_ffe_exec', 1)
+        self.write_tc_reg('wme_ffe_exec', 0)
+
+    def print(self, *args, **kwargs):
+        if self.print_mode == 'debug':
+            print(*args, **kwargs)
+
+    def run_test(self):
+        # record starting time
+        start_time = time.time()
+
+        # Start a batch if running in batch mode
+        if self.use_batch_mode:
+            self.start_batch()
+
+        # Initialize
+        if self.uart and not self.bit_bang:
+            self.set_sleep(self.jtag_sleep_us)
+        self.do_init()
+
+        # Clear emulator reset
+        self.set_emu_rst(0)
+
+        # Reset JTAG
+        self.print('Reset JTAG')
+        self.do_reset()
+
+        # Release other reset signals
+        self.print('Release other reset signals')
+        self.set_rstb(1)
+
+        # Soft reset
+        self.print('Soft reset')
+        self.write_tc_reg('int_rstb', 1)
+        self.write_tc_reg('en_inbuf', 1)
+        self.write_tc_reg('en_gf', 1)
+        self.write_tc_reg('en_v2t', 1)
+
+        # read the ID
+        self.print('Reading ID...')
+        self.shift_ir(1, 5)
+        id_result = self.shift_dr(0, 32)
+
+        # Set PFD offset
+        self.print('Set PFD offset')
+        for k in range(16):
+            self.write_tc_reg(f'ext_pfd_offset[{k}]', 0)
+
+        # Configure PRBS checker
+        self.print('Configure the PRBS checker')
+        self.write_tc_reg('sel_prbs_mux', 1) # "0" is ADC, "1" is FFE, "3" is BIST
+
+        # Release the PRBS checker from reset
+        self.print('Release the PRBS checker from reset')
+        self.write_tc_reg('prbs_rstb', 1)
+
+        # Set up the FFE
+        dt=1.0/(16.0e9)
+        tau=25.0e-12
+        coeff0 = 128.0/(1.0-exp(-dt/tau))
+        coeff1 = -128.0*exp(-dt/tau)/(1.0-exp(-dt/tau))
+        for loop_var in range(16):
+            for loop_var2 in range(self.ffe_length):
+                if (loop_var2 == 0):
+                    # The argument order for load() is depth, width, value
+                    self.load_weight(loop_var2, loop_var, int(round(coeff0)))
+                elif (loop_var2 == 1):
+                    self.load_weight(loop_var2, loop_var, int(round(coeff1)))
+                else:
+                    self.load_weight(loop_var2, loop_var, 0)
+            self.write_tc_reg(f'ffe_shift[{loop_var}]', 7)
+
+        # Configure the CDR offsets
+        self.print('Configure the CDR offsets')
+        self.write_tc_reg('ext_pi_ctl_offset[0]', 0)
+        self.write_tc_reg('ext_pi_ctl_offset[1]', 128)
+        self.write_tc_reg('ext_pi_ctl_offset[2]', 256)
+        self.write_tc_reg('ext_pi_ctl_offset[3]', 384)
+        self.write_tc_reg('en_ext_max_sel_mux', 1)
+
+        # Configure the retimer
+        self.print('Configuring the retimer...')
+        self.write_tc_reg('retimer_mux_ctrl_1', 0xffff)
+        self.write_tc_reg('retimer_mux_ctrl_2', 0xffff)
+
+        # Configure the CDR
+        self.print('Configuring the CDR...')
+        self.write_tc_reg('cdr_rstb', 0)
+        self.write_tc_reg('Kp', 18)
+        self.write_tc_reg('Ki', 0)
+        self.write_tc_reg('invert', 1)
+        self.write_tc_reg('en_freq_est', 0)
+        self.write_tc_reg('en_ext_pi_ctl', 0)
+        self.write_tc_reg('sel_inp_mux', 1) # "0": use ADC output, "1": use FFE output
+
+        # Re-initialize ordering
+        self.print('Re-initialize ADC ordering')
+        self.write_tc_reg('en_v2t', 0)
+        self.write_tc_reg('en_v2t', 1)
+
+        # Release the CDR from reset, then wait for it to lock
+        # TODO: explore why it is not sufficient to pulse cdr_rstb low here
+        # (i.e., seems that it must be set to zero while configuring CDR parameters
+        self.print('Wait for the CDR to lock')
+        self.write_tc_reg('cdr_rstb', 1)
+        if self.use_batch_mode:
+            self.run_batch()
+        time.sleep(self.cdr_settling_time)
+        if self.use_batch_mode:
+            self.start_batch()
+
+        # Run PRBS test
+        self.print('Run PRBS test')
+        self.write_tc_reg('prbs_checker_mode', 2)
+        if self.use_batch_mode:
+            self.run_batch()
+        time.sleep(self.prbs_test_dur)
+        if self.use_batch_mode:
+            self.start_batch()
+        self.write_tc_reg('prbs_checker_mode', 3)
+
+        # Read out PRBS test results
+
+        self.print('Read out PRBS test results')
+
+        err_bits = 0
+        err_bits = err_bits | self.read_sc_reg('prbs_err_bits_upper')
+        err_bits = err_bits << 32
+        err_bits = err_bits | self.read_sc_reg('prbs_err_bits_lower')
+
+        total_bits = 0
+        total_bits = total_bits | self.read_sc_reg('prbs_total_bits_upper')
+        total_bits = total_bits << 32
+        total_bits = total_bits | self.read_sc_reg('prbs_total_bits_lower')
+
+        # Run batch if needed, converting DeferredValue objects to integers afterwards
+        if self.use_batch_mode:
+            self.run_batch()
+            id_result = id_result.value
+            err_bits = err_bits.value
+            total_bits = total_bits.value
+
+        # Measure stop time
+        stop_time = time.time()
+        print(f'Test took {stop_time - start_time} seconds.')
+        print(f'Total bytes transmitted: {self.uart_bytes_total}')
+
+        # Print results
+        print(f'id_result: {id_result}')
+        print(f'err_bits: {err_bits}')
+        print(f'total_bits: {total_bits}')
+
+        # Check results
+        print('Checking the results...')
+        assert id_result == 497598771, 'ID mismatch'
+        assert err_bits == 0, 'Bit error detected'
+        assert total_bits > 100000, 'Not enough bits detected'
+
+        # Finish test
+        print('OK!')
+
+def main():
+    t = JtagTester(use_batch_mode=True, print_mode='debug', bit_bang=True)
+    t.run_test()
+
+if __name__ == '__main__':
+    main()

--- a/experiments/jtag_comparison/test_jtag.py
+++ b/experiments/jtag_comparison/test_jtag.py
@@ -385,7 +385,10 @@ class JtagTester:
             # Return result
             return retval
         else:
-            return self.ser_cmd(f'SDR {val} {width}', expect_output=True)
+            if expect_output:
+                return self.ser_cmd(f'SDR {val} {width}', expect_output=True)
+            else:
+                self.ser_cmd(f'QSDR {val} {width}')
 
     def write_tc_reg(self, name, val):
         # update stats
@@ -662,13 +665,13 @@ class JtagTester:
 
 def main():
     # UART-based tests
-    #t = JtagTester(use_batch_mode=False, bit_bang=False, print_mode='test')
+    t = JtagTester(use_batch_mode=False, bit_bang=False, print_mode='test')
     #t = JtagTester(use_batch_mode=True, bit_bang=False, print_mode='test')
     #t = JtagTester(use_batch_mode=False, bit_bang=True, print_mode='debug')
     #t = JtagTester(use_batch_mode=True, bit_bang=True, print_mode='debug')
 
     # VIO-based test
-    t = JtagTester(comm_style='vio', bit_bang=True, use_ffe=True, print_mode='debug')
+    #t = JtagTester(comm_style='vio', bit_bang=True, use_ffe=True, print_mode='debug')
 
     # Run the test
     t.run_test()

--- a/inc/fpga/iotype.sv
+++ b/inc/fpga/iotype.sv
@@ -1,28 +1,7 @@
 `ifndef __IOTYPE_SV__
 `define __IOTYPE_SV__
 
-    `include "svreal.sv"
-
-    // analog representation
-    // resolution is about 0.2 mV
-    // range is about +/- 30 V
-
-    `define PWL_WIDTH 18
-    `define PWL_EXPONENT -12
-    `define PWL_RANGE 30.0
-    `define pwl_t wire logic signed [((`PWL_WIDTH)-1):0]
-
-    `define DECL_PWL(name) \
-        `REAL_FROM_WIDTH_EXP(``name``, `PWL_WIDTH, `PWL_EXPONENT)
-    `define DECL_DT(name) \
-        `REAL_FROM_WIDTH_EXP(``name``, `DT_WIDTH, `DT_EXPONENT)
-
-    `define ATTACH_PWL_PARAMS(name) \
-        localparam real `RANGE_PARAM_REAL(``name``) = `PWL_RANGE; \
-        localparam integer `WIDTH_PARAM_REAL(``name``) = `PWL_WIDTH; \
-        localparam integer `EXPONENT_PARAM_REAL(``name``) = `PWL_EXPONENT \
-
-	// not implemented yet
+    `define pwl_t wire logic [15:0]
 	`define real_t wire logic
 	`define voltage_t wire logic
 

--- a/inc/fpga/iotype.sv
+++ b/inc/fpga/iotype.sv
@@ -1,7 +1,33 @@
 `ifndef __IOTYPE_SV__
 `define __IOTYPE_SV__
 
-    `define pwl_t wire logic [15:0]
+
+    `ifdef FPGA_MACRO_MODEL
+        `define pwl_t wire logic [15:0]
+    `else
+        `include "svreal.sv"
+
+        // analog representation
+        // resolution is about 0.2 mV
+        // range is about +/- 30 V
+
+        `define PWL_WIDTH 18
+        `define PWL_EXPONENT -12
+        `define PWL_RANGE 30.0
+        `define pwl_t wire logic signed [((`PWL_WIDTH)-1):0]
+
+        `define DECL_PWL(name) \
+            `REAL_FROM_WIDTH_EXP(``name``, `PWL_WIDTH, `PWL_EXPONENT)
+        `define DECL_DT(name) \
+            `REAL_FROM_WIDTH_EXP(``name``, `DT_WIDTH, `DT_EXPONENT)
+
+        `define ATTACH_PWL_PARAMS(name) \
+            localparam real `RANGE_PARAM_REAL(``name``) = `PWL_RANGE; \
+            localparam integer `WIDTH_PARAM_REAL(``name``) = `PWL_WIDTH; \
+            localparam integer `EXPONENT_PARAM_REAL(``name``) = `PWL_EXPONENT
+    `endif // `ifdef FPGA_MACRO_MODEL
+
+
 	`define real_t wire logic
 	`define voltage_t wire logic
 

--- a/make.py
+++ b/make.py
@@ -9,6 +9,7 @@ def create_fpga_graph():
     graph.add_config('system', folders=['config'])
     graph.add_config('jtag_config', folders=['config'])
     graph.add_config('chan', folders=['config', 'fpga'])
+    graph.add_config('analog_slice_cfg', folders=['config', 'fpga'])
     graph.add_config('osc_model', folders=['config', 'fpga'])
     graph.add_config('rx_adc', folders=['config', 'fpga'])
     graph.add_config('tx', folders=['config', 'fpga'])
@@ -33,6 +34,9 @@ def create_fpga_graph():
     graph.add_python('chan_core', 'chan_core', 'ChannelCore', view='fpga_models',
                      folders=['dragonphy', 'fpga_models'], sources={'adapt_fir'},
                      configs={'chan'})
+    graph.add_python('analog_slice', 'analog_slice', 'AnalogSlice', view='fpga_models',
+                     folders=['dragonphy', 'fpga_models'], sources={'adapt_fir'},
+                     configs={'analog_slice_cfg'})
     graph.add_python('osc_model_core', 'osc_model_core', 'OscModelCore', view='fpga_models',
                      folders=['dragonphy', 'fpga_models'], configs={'osc_model'})
     graph.add_python('rx_adc_core', 'rx_adc_core', 'RXAdcCore', view='fpga_models',

--- a/regress.sh
+++ b/regress.sh
@@ -27,7 +27,9 @@ if [[ -z "${FPGA_SERVER}" ]]; then
         -s -v -r s --cov-report=xml --cov=dragonphy --durations=0
 else
     python make.py --view fpga
-    xvfb-run pytest tests/fpga_block_tests tests/fpga_system_tests \
+    xvfb-run pytest tests/fpga_block_tests tests/fpga_system_tests/emu \
+        tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_1 \
+        tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_2 \
         -s -v -r s --cov-report=xml --cov=dragonphy --durations=0 -x
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 requires_list = [
     # anasymod ecosystem
     'svreal==0.2.2',
-    'msdsl==0.2.5',
+    'msdsl==0.2.6',
     'anasymod==0.2.9',
     # system-verilog parser
     'svinst==0.1.5',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requires_list = [
     # anasymod ecosystem
     'svreal==0.2.2',
     'msdsl==0.2.6',
-    'anasymod==0.2.9',
+    'anasymod==0.3.2',
     # system-verilog parser
     'svinst==0.1.5',
     # magma ecosystem dependencies

--- a/tests/cpu_block_tests/pb1_only/test_pb1_only.py
+++ b/tests/cpu_block_tests/pb1_only/test_pb1_only.py
@@ -13,7 +13,6 @@ from dragonphy import *
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-SIMULATOR = 'ncsim'
 
 CLK_REF_FREQ = 4e9
 PH_ERR_TOL   = 1e-12
@@ -39,7 +38,11 @@ class Results:
         self.freq = 1e9*np.array([elem.value for elem in self.freq], dtype=float)
         self.duty = np.array([elem.value for elem in self.duty], dtype=float)
 
-def test_sim():
+def test_sim(simulator_name):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'ncsim'
+
     # declare circuit
     class dut(m.Circuit):
         name = 'test'
@@ -90,7 +93,7 @@ def test_sim():
 
     t.compile_and_run(
         target='system-verilog',
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=deps,
         ext_model_file=True,
         disp_type='realtime',

--- a/tests/cpu_block_tests/pb_only/test_pb_only.py
+++ b/tests/cpu_block_tests/pb_only/test_pb_only.py
@@ -13,7 +13,6 @@ from dragonphy import *
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-SIMULATOR = 'ncsim'
 
 CLK_REF_FREQ = 4e9
 N_BLENDER = 4
@@ -41,7 +40,11 @@ class Results:
         self.freq = 1e9*np.array([elem.value for elem in self.freq], dtype=float)
         self.duty = np.array([elem.value for elem in self.duty], dtype=float)
 
-def test_sim():
+def test_sim(simulator_name):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'ncsim'
+
     # declare circuit
     class dut(m.Circuit):
         name = 'test'
@@ -78,7 +81,7 @@ def test_sim():
 
     t.compile_and_run(
         target='system-verilog',
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=deps,
         ext_model_file=True,
         disp_type='realtime',

--- a/tests/cpu_block_tests/prbs_checker_core_only/test_prbs_checker_core.py
+++ b/tests/cpu_block_tests/prbs_checker_core_only/test_prbs_checker_core.py
@@ -13,13 +13,16 @@ from dragonphy import get_file
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-if shutil.which('iverilog'):
-    SIMULATOR = 'iverilog'
-else:
-    SIMULATOR = 'ncsim'
 
 @pytest.mark.parametrize('n_prbs', [7, 9, 11, 15, 17, 20, 23, 29, 31])
-def test_sim(n_prbs, n_channels=16, n_trials=256):
+def test_sim(simulator_name, n_prbs, n_channels=16, n_trials=256):
+    # set defaults
+    if simulator_name is None:
+        if shutil.which('iverilog'):
+            simulator_name = 'iverilog'
+        else:
+            simulator_name = 'ncsim'
+
     # determine the right equation
     if n_prbs == 7:
         eqn = (1 << 6) | (1 << 5)
@@ -94,7 +97,7 @@ def test_sim(n_prbs, n_channels=16, n_trials=256):
     # run the test
     t.compile_and_run(
         target='system-verilog',
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=[
             get_file('vlog/tb/prbs_generator.sv'),
             get_file('vlog/chip_src/prbs/prbs_checker_core.sv'),

--- a/tests/cpu_block_tests/prbs_checker_only/test_prbs_checker.py
+++ b/tests/cpu_block_tests/prbs_checker_only/test_prbs_checker.py
@@ -13,10 +13,6 @@ from dragonphy import get_file
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-if shutil.which('iverilog'):
-    SIMULATOR = 'iverilog'
-else:
-    SIMULATOR = 'ncsim'
 
 RESET  = 0b00
 ALIGN  = 0b01
@@ -24,7 +20,14 @@ TEST   = 0b10
 FREEZE = 0b11
 
 @pytest.mark.parametrize('n_prbs', [7, 9, 11, 15, 17, 20, 23, 29, 31])
-def test_sim(n_prbs, n_channels=16, n_trials=256):
+def test_sim(simulator_name, n_prbs, n_channels=16, n_trials=256):
+    # set defaults
+    if simulator_name is None:
+        if shutil.which('iverilog'):
+            simulator_name = 'iverilog'
+        else:
+            simulator_name = 'ncsim'
+
     # determine the right equation
     if n_prbs == 7:
         eqn = (1 << 6) | (1 << 5)
@@ -110,7 +113,7 @@ def test_sim(n_prbs, n_channels=16, n_trials=256):
     # run the test
     t.compile_and_run(
         target='system-verilog',
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=[
             get_file('vlog/tb/prbs_generator.sv'),
             get_file('vlog/chip_src/prbs/prbs_checker_core.sv'),

--- a/tests/cpu_block_tests/prbs_generator_syn_only/test_prbs_generator_syn.py
+++ b/tests/cpu_block_tests/prbs_generator_syn_only/test_prbs_generator_syn.py
@@ -11,12 +11,15 @@ from dragonphy import get_file
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-if shutil.which('iverilog'):
-    SIMULATOR = 'iverilog'
-else:
-    SIMULATOR = 'ncsim'
 
-def test_sim():
+def test_sim(simulator_name):
+    # set defaults
+    if simulator_name is None:
+        if shutil.which('iverilog'):
+            simulator_name = 'iverilog'
+        else:
+            simulator_name = 'ncsim'
+
     # declare circuit
     class dut(m.Circuit):
         name = 'prbs_generator_syn'
@@ -65,7 +68,7 @@ def test_sim():
     # run the test
     t.compile_and_run(
         target='system-verilog',
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=[
             get_file('vlog/chip_src/prbs/prbs_generator_syn.sv'),
         ],

--- a/tests/cpu_system_tests/ac/test_ac.py
+++ b/tests/cpu_system_tests/ac/test_ac.py
@@ -8,7 +8,6 @@ from dragonphy import *
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-SIMULATOR = 'ncsim'
 
 def test_sim(dump_waveforms):
     deps = get_deps_cpu_sim(impl_file=THIS_DIR / 'test.sv')

--- a/tests/cpu_system_tests/ac_replica/test_ac_replica.py
+++ b/tests/cpu_system_tests/ac_replica/test_ac_replica.py
@@ -8,7 +8,6 @@ from dragonphy import *
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-SIMULATOR = 'ncsim'
 
 def test_sim(dump_waveforms):
     deps = get_deps_cpu_sim(impl_file=THIS_DIR / 'test.sv')

--- a/tests/cpu_system_tests/dc/test_dc.py
+++ b/tests/cpu_system_tests/dc/test_dc.py
@@ -9,7 +9,6 @@ from dragonphy import *
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
-SIMULATOR = 'ncsim'
 
 def test_sim(dump_waveforms):
     deps = get_deps_cpu_sim(impl_file=THIS_DIR / 'test.sv')

--- a/tests/fpga_block_tests/adc_model/test_adc_model.py
+++ b/tests/fpga_block_tests/adc_model/test_adc_model.py
@@ -15,7 +15,6 @@ from msdsl import get_msdsl_header
 from dragonphy import get_file
 
 BUILD_DIR = Path(__file__).resolve().parent / 'build'
-SIMULATOR = 'vivado'
 
 def model(in_, n, vref):
     # determine sign
@@ -33,7 +32,11 @@ def model(in_, n, vref):
     # return result
     return sgn, mag
 
-def test_chan_model(n=8, vref=0.4, should_print=False):
+def test_chan_model(simulator_name, n=8, vref=0.4, should_print=False):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
     # declare circuit
     class dut(m.Circuit):
         name = 'test_adc_model'
@@ -93,7 +96,7 @@ def test_chan_model(n=8, vref=0.4, should_print=False):
     t.compile_and_run(
         target='system-verilog',
         directory=BUILD_DIR,
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=[get_file('build/fpga_models/rx_adc_core/rx_adc_core.sv'),
                   get_file('tests/fpga_block_tests/adc_model/test_adc_model.sv')],
         inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],

--- a/tests/fpga_block_tests/analog_core/test_analog_core.py
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.py
@@ -156,7 +156,7 @@ def test_analog_core(simulator_name, dump_waveforms, num_tests=100):
     print(ext_srcs)
 
     # waveform dumping options
-    defines = {}
+    defines = {'FPGA_MACRO_MODEL': True}
     flags = []
     if simulator_name == 'ncsim':
         flags += ['-unbuffered']

--- a/tests/fpga_block_tests/analog_core/test_analog_core.py
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.py
@@ -1,0 +1,189 @@
+# general imports
+from pathlib import Path
+import random
+from math import floor
+import yaml
+
+# AHA imports
+import magma as m
+import fault
+
+# FPGA-specific imports
+from svreal import get_svreal_header
+from msdsl import get_msdsl_header
+
+# DragonPHY imports
+from dragonphy import get_file, get_dir, Filter
+
+THIS_DIR = Path(__file__).resolve().parent
+BUILD_DIR = THIS_DIR / 'build'
+
+DELTA = 100e-9
+TPER = 1e-6
+
+# read YAML file that was used to configure the generated model
+CFG = yaml.load(open(get_file('config/fpga/analog_slice_cfg.yml'), 'r'))
+
+# read channel data
+CHAN = Filter.from_file(get_file('build/chip_src/adapt_fir/chan.npy'))
+
+def adc_model(in_):
+    # determine sign
+    if in_ < 0:
+        sgn = 0
+    else:
+        sgn = 1
+
+    # determine magnitude
+    in_abs = abs(in_)
+    mag_real = (abs(in_abs) / CFG['vref_rx']) * ((2**(CFG['n_adc']-1)) - 1)
+    mag_unclamped = int(floor(mag_real))
+    mag = min(max(mag_unclamped, 0), (2**(CFG['n_adc']-1))-1)
+
+    # return result
+    return sgn, mag
+
+def channel_model(slice_offset, pi_ctl, all_bits):
+    # compute sample time
+    t_samp = (slice_offset + (pi_ctl / (2 ** CFG['pi_ctl_width']))) / CFG['freq_rx']
+
+    # build up the sample value through superposition
+    sample_value = 0
+    for k, bit in enumerate(all_bits):
+        weight = (2*(bit-0.5)) * CFG['vref_tx']  # +/- vref_tx
+        t_rise = (CFG['slices_per_bank'] / CFG['freq_rx']) - (k + 1) * (1.0 / CFG['freq_tx'])
+        t_fall = t_rise + (1.0 / CFG['freq_tx'])
+        sample_value += weight * (CHAN.interp(t_samp-t_rise)-CHAN.interp(t_samp-t_fall))
+
+    return sample_value
+
+def check_adc_result(sgn_meas, mag_meas, sgn_expct, mag_expct):
+    # compute measured value as signed integer
+    # note that a sign bit of "0" (not "1") means that the value is negative
+    meas = mag_meas
+    if sgn_meas == 0:
+        meas *= -1
+
+    # compute expected value as signed integer
+    expct = mag_expct
+    if sgn_expct == 0:
+        expct *= -1
+
+    # check result
+    if not ((expct-1) <= meas <= (expct+1)):
+        raise Exception('BAD!')
+
+def test_analog_core(simulator_name, num_tests=5):
+    # set seed for repeatable behavior
+    random.seed(0)
+
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
+    # set up the IO definitions
+    io_dict = {}
+    io_dict['bits'] = m.In(m.Bits[16])
+    for k in range(4):
+        io_dict[f'ctl_pi_{k}'] = m.In(m.Bits[9])
+    for k in range(16):
+        io_dict[f'adder_out_{k}'] = m.Out(m.Bits[8])
+    io_dict['sign_out'] = m.Out(m.Bits[16])
+    io_dict['clk'] = m.BitIn
+    io_dict['rst'] = m.BitIn
+
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'test_analog_core'
+        io = m.IO(**io_dict)
+
+    # create the tester
+    t = fault.Tester(dut)
+
+    def cycle(k=1):
+        for _ in range(k):
+            t.delay(TPER/2 - DELTA)
+            t.poke(dut.clk, 0)
+            t.delay(TPER/2)
+            t.poke(dut.clk, 1)
+            t.delay(DELTA)
+
+    def to_bv(lis):
+        return int(''.join(str(elem) for elem in lis), 2)
+
+    def poke_bits(bits):
+        t.poke(dut.bits, to_bv(bits))
+
+    def poke_pi_ctl(pi_ctl):
+        for k in range(4):
+            t.poke(getattr(dut, f'ctl_pi_{k}'), pi_ctl[k])
+
+    def get_adder_out():
+        retval = []
+        for k in range(16):
+            retval.append(t.get_value(getattr(dut, f'adder_out_{k}')))
+        return retval
+
+    # build up a list of test cases
+    test_cases = []
+    for x in range(num_tests):
+        pi_ctl = [random.randint(0, (1 << CFG['pi_ctl_width']) - 1) for _ in range(4)]
+        new_bits = [random.randint(0, 1) for _ in range(16)]
+        test_cases.append([pi_ctl, new_bits])
+
+    # initialize
+    t.zero_inputs()
+    t.poke(dut.rst, 1)
+    cycle(10)
+    t.poke(dut.rst, 0)
+    for j in range(1 + CFG['num_chunks']):
+        cycle()
+
+    # run test cases
+    results = []
+    for pi_ctl, new_bits in test_cases:
+        poke_bits(new_bits)
+        poke_pi_ctl(pi_ctl)
+        for j in range(2+CFG['num_chunks']):
+            cycle()
+        results.append([t.get_value(dut.sign_out), get_adder_out()])
+
+    # run a few cycles at the end for better waveform visibility
+    cycle(5)
+
+    # run the simulation
+    t.compile_and_run(
+        target='system-verilog',
+        directory=BUILD_DIR,
+        simulator=simulator_name,
+        ext_srcs=[
+            get_file('build/fpga_models/analog_slice/analog_slice.sv'),
+            get_file('vlog/fpga_models/analog_core/analog_core.sv'),
+            THIS_DIR / 'test_analog_core.sv'
+        ],
+        inc_dirs=[
+            get_svreal_header().parent,
+            get_msdsl_header().parent,
+            get_dir('inc/fpga')
+        ],
+        ext_model_file=True,
+        disp_type='realtime',
+        dump_waveforms=True
+    )
+
+    # process the results
+    # for k, (pi_ctl, all_bits, sgn_meas, mag_meas) in enumerate(test_cases):
+    #     # compute the expected ADC value
+    #     analog_sample = channel_model(slice_offset, pi_ctl, all_bits)
+    #     sgn_expct, mag_expct = adc_model(analog_sample)
+    #
+    #     # print measured and expected
+    #     print(f'Test case #{k}: slice_offset={slice_offset}, pi_ctl={pi_ctl}, all_bits={all_bits}')
+    #     print(f'[measured] sgn: {sgn_meas.value}, mag: {mag_meas.value}')
+    #     print(f'[expected] sgn: {sgn_expct}, mag: {mag_expct}, analog_sample: {analog_sample}')
+    #
+    #     # check result
+    #     check_adc_result(sgn_meas.value, mag_meas.value, sgn_expct, mag_expct)
+
+    # declare success
+    print('Success!')

--- a/tests/fpga_block_tests/analog_core/test_analog_core.sv
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.sv
@@ -1,0 +1,78 @@
+module test_analog_core #(
+    parameter integer Nti=16,
+    parameter integer Npi=9,
+    parameter integer Nadc=8,
+    parameter integer Nout=4
+) (
+    // Input bits
+    input [(Nti-1):0] bits,
+
+    // PI control bits
+    input [Npi-1:0] ctl_pi_0,
+    input [Npi-1:0] ctl_pi_1,
+    input [Npi-1:0] ctl_pi_2,
+    input [Npi-1:0] ctl_pi_3,
+
+    // ADC magnitude outputs
+    output [(Nadc-1):0] adder_out_0,
+    output [(Nadc-1):0] adder_out_1,
+    output [(Nadc-1):0] adder_out_2,
+    output [(Nadc-1):0] adder_out_3,
+    output [(Nadc-1):0] adder_out_4,
+    output [(Nadc-1):0] adder_out_5,
+    output [(Nadc-1):0] adder_out_6,
+    output [(Nadc-1):0] adder_out_7,
+    output [(Nadc-1):0] adder_out_8,
+    output [(Nadc-1):0] adder_out_9,
+    output [(Nadc-1):0] adder_out_10,
+    output [(Nadc-1):0] adder_out_11,
+    output [(Nadc-1):0] adder_out_12,
+    output [(Nadc-1):0] adder_out_13,
+    output [(Nadc-1):0] adder_out_14,
+    output [(Nadc-1):0] adder_out_15,
+
+    // ADC sign outputs
+    output [(Nti-1):0] sign_out,
+
+    // Emulator clock and reset
+    input clk,
+    input rst
+);
+    // wire ctl_pi
+    logic [Npi-1:0] ctl_pi [Nout-1:0];
+    assign ctl_pi[0] = ctl_pi_0;
+    assign ctl_pi[1] = ctl_pi_1;
+    assign ctl_pi[2] = ctl_pi_2;
+    assign ctl_pi[3] = ctl_pi_3;
+
+    // wire adder_out
+    logic [Nadc-1:0] adder_out [(Nti-1):0];
+    assign adder_out_0 = adder_out[0];
+    assign adder_out_1 = adder_out[1];
+    assign adder_out_2 = adder_out[2];
+    assign adder_out_3 = adder_out[3];
+    assign adder_out_4 = adder_out[4];
+    assign adder_out_5 = adder_out[5];
+    assign adder_out_6 = adder_out[6];
+    assign adder_out_7 = adder_out[7];
+    assign adder_out_8 = adder_out[8];
+    assign adder_out_9 = adder_out[9];
+    assign adder_out_10 = adder_out[10];
+    assign adder_out_11 = adder_out[11];
+    assign adder_out_12 = adder_out[12];
+    assign adder_out_13 = adder_out[13];
+    assign adder_out_14 = adder_out[14];
+    assign adder_out_15 = adder_out[15];
+
+    // instantiate the model
+    analog_core analog_core_i (
+        .rx_inp(bits),
+        .ctl_pi(ctl_pi),
+        .adder_out(adder_out),
+        .sign_out(sign_out)
+    );
+
+    // wire emulator control signals through the hierarchy
+    assign analog_core_i.emu_clk = clk;
+    assign analog_core_i.emu_rst = rst;
+endmodule

--- a/tests/fpga_block_tests/analog_core/test_analog_core.sv
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.sv
@@ -69,7 +69,24 @@ module test_analog_core import const_pack::*; #(
         .ctl_pi(ctl_pi),
         .adder_out(adder_out),
         .sign_out(sign_out),
-        .adbg_intf_i(adbg_intf_i)
+        .adbg_intf_i(adbg_intf_i),
+
+        // unused I/O
+        // explicitly indicated to prevent noisy warnings
+        .clk_adc(),
+        .adder_out_rep(),
+        .sign_out_rep(),
+        .rx_inn(),
+        .Vcm(),
+        .rx_inp_test(),
+        .rx_inn_test(),
+        .ext_clk(),
+        .mdll_clk(),
+        .ext_clk_test0(),
+        .ext_clk_test1(),
+        .clk_async(),
+        .ctl_valid(),
+        .Vcal()
     );
 
     // wire emulator control signals through the hierarchy

--- a/tests/fpga_block_tests/analog_core/test_analog_core.sv
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.sv
@@ -1,8 +1,4 @@
-module test_analog_core #(
-    parameter integer Nti=16,
-    parameter integer Npi=9,
-    parameter integer Nadc=8,
-    parameter integer Nout=4
+module test_analog_core import const_pack::*; #(
 ) (
     // Input bits
     input [(Nti-1):0] bits,
@@ -64,15 +60,27 @@ module test_analog_core #(
     assign adder_out_14 = adder_out[14];
     assign adder_out_15 = adder_out[15];
 
+    // instantiate the debug interface (although it is unused)
+    acore_debug_intf adbg_intf_i ();
+
     // instantiate the model
     analog_core analog_core_i (
         .rx_inp(bits),
         .ctl_pi(ctl_pi),
         .adder_out(adder_out),
-        .sign_out(sign_out)
+        .sign_out(sign_out),
+        .adbg_intf_i(adbg_intf_i)
     );
 
     // wire emulator control signals through the hierarchy
     assign analog_core_i.emu_clk = clk;
     assign analog_core_i.emu_rst = rst;
+
+    // waveform dumping
+    initial begin
+        `ifdef DUMP_WAVEFORMS
+	        $shm_open("waves.shm");
+	        $shm_probe("ASMC");
+        `endif
+    end
 endmodule

--- a/tests/fpga_block_tests/analog_slice/test_analog_slice.py
+++ b/tests/fpga_block_tests/analog_slice/test_analog_slice.py
@@ -74,7 +74,7 @@ def check_adc_result(sgn_meas, mag_meas, sgn_expct, mag_expct):
         raise Exception('BAD!')
 
 @pytest.mark.parametrize('slice_offset', [0, 1, 2, 3])
-def test_analog_slice(simulator_name, slice_offset, num_tests=100):
+def test_analog_slice(simulator_name, slice_offset, dump_waveforms, num_tests=100):
     # set seed for repeatable behavior
     random.seed(0)
 
@@ -167,15 +167,27 @@ def test_analog_slice(simulator_name, slice_offset, num_tests=100):
         # gather results
         test_cases[i].extend([t.get_value(dut.out_sgn), t.get_value(dut.out_mag)])
 
+    # waveform dumping options
+    flags = []
+    if simulator_name == 'ncsim':
+        flags += ['-unbuffered']
+
     # run the simulation
     t.compile_and_run(
         target='system-verilog',
         directory=BUILD_DIR,
         simulator=simulator_name,
         ext_srcs=[get_file('build/fpga_models/analog_slice/analog_slice.sv')],
-        inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],
+        inc_dirs=[
+            get_svreal_header().parent,
+            get_msdsl_header().parent
+        ],
         ext_model_file=True,
-        disp_type='realtime'
+        disp_type='realtime',
+        dump_waveforms=dump_waveforms,
+        flags=flags,
+        timescale='1fs/1fs',
+        num_cycles=1e12
     )
 
     # process the results

--- a/tests/fpga_block_tests/analog_slice/test_analog_slice.py
+++ b/tests/fpga_block_tests/analog_slice/test_analog_slice.py
@@ -1,0 +1,197 @@
+# general imports
+from pathlib import Path
+import random
+from math import log2, ceil, floor
+import yaml
+import pytest
+
+# AHA imports
+import magma as m
+import fault
+
+# FPGA-specific imports
+from svreal import get_svreal_header
+from msdsl import get_msdsl_header
+
+# DragonPHY imports
+from dragonphy import get_file, Filter
+
+BUILD_DIR = Path(__file__).resolve().parent / 'build'
+
+DELTA = 100e-9
+TPER = 1e-6
+
+# read YAML file that was used to configure the generated model
+CFG = yaml.load(open(get_file('config/fpga/analog_slice_cfg.yml'), 'r'))
+
+# read channel data
+CHAN = Filter.from_file(get_file('build/chip_src/adapt_fir/chan.npy'))
+
+def adc_model(in_):
+    # determine sign
+    if in_ < 0:
+        sgn = 0
+    else:
+        sgn = 1
+
+    # determine magnitude
+    in_abs = abs(in_)
+    mag_real = (abs(in_abs) / CFG['vref_rx']) * ((2**(CFG['n_adc']-1)) - 1)
+    mag_unclamped = int(floor(mag_real))
+    mag = min(max(mag_unclamped, 0), (2**(CFG['n_adc']-1))-1)
+
+    # return result
+    return sgn, mag
+
+def channel_model(slice_offset, pi_ctl, all_bits):
+    # compute sample time
+    t_samp = (slice_offset + (pi_ctl / (2 ** CFG['pi_ctl_width']))) / CFG['freq_rx']
+
+    # build up the sample value through superposition
+    sample_value = 0
+    for k, bit in enumerate(all_bits):
+        weight = (2*(bit-0.5)) * CFG['vref_tx']  # +/- vref_tx
+        t_rise = (CFG['slices_per_bank'] / CFG['freq_rx']) - (k + 1) * (1.0 / CFG['freq_tx'])
+        t_fall = t_rise + (1.0 / CFG['freq_tx'])
+        sample_value += weight * (CHAN.interp(t_samp-t_rise)-CHAN.interp(t_samp-t_fall))
+
+    return sample_value
+
+def check_adc_result(sgn_meas, mag_meas, sgn_expct, mag_expct):
+    # compute measured value as signed integer
+    # note that a sign bit of "0" (not "1") means that the value is negative
+    meas = mag_meas
+    if sgn_meas == 0:
+        meas *= -1
+
+    # compute expected value as signed integer
+    expct = mag_expct
+    if sgn_expct == 0:
+        expct *= -1
+
+    # check result
+    if not ((expct-1) <= meas <= (expct+1)):
+        raise Exception('BAD!')
+
+@pytest.mark.parametrize('slice_offset', [0, 1, 2, 3])
+def test_chan_model(simulator_name, slice_offset, num_tests=100):
+    # set seed for repeatable behavior
+    random.seed(0)
+
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'analog_slice'
+        io = m.IO(
+            chunk=m.In(m.Bits[CFG['chunk_width']]),
+            chunk_idx=m.In(m.Bits[int(ceil(log2(CFG['num_chunks'])))]),
+            pi_ctl=m.In(m.Bits[CFG['pi_ctl_width']]),
+            slice_offset=m.In(m.Bits[int(ceil(log2(CFG['slices_per_bank'])))]),
+            sample_ctl=m.BitIn,
+            incr_sum=m.BitIn,
+            write_output=m.BitIn,
+            out_sgn=m.BitOut,
+            out_mag=m.Out(m.Bits[CFG['n_adc']]),
+            clk=m.BitIn,
+            rst=m.BitIn
+        )
+
+    # create the tester
+    t = fault.Tester(dut)
+
+    def cycle(k=1):
+        for _ in range(k):
+            t.delay(TPER/2 - DELTA)
+            t.poke(dut.clk, 0)
+            t.delay(TPER/2)
+            t.poke(dut.clk, 1)
+            t.delay(DELTA)
+
+    def to_bv(lis):
+        return int(''.join(str(elem) for elem in lis), 2)
+
+    # build up a list of test cases
+    test_cases = []
+    for x in range(num_tests):
+        pi_ctl = random.randint(0, (1 << CFG['pi_ctl_width']) - 1)
+        all_bits = [random.randint(0, 1) for _ in range(CFG['chunk_width'] * CFG['num_chunks'])]
+        test_cases.append([pi_ctl, all_bits])
+
+    # initialize
+    # two cycles of reset -- one to reset DFFs, then another to read out ROM values
+    # after the addresses are no longer X
+    t.zero_inputs()
+    t.poke(dut.slice_offset, slice_offset)
+    t.poke(dut.rst, 1)
+    cycle(2)
+    t.poke(dut.rst, 0)
+
+    # first cycle
+    t.poke(dut.chunk, 0)
+    t.poke(dut.chunk_idx, 0)
+    t.poke(dut.pi_ctl, test_cases[0][0])
+    t.poke(dut.sample_ctl, 1)
+    t.poke(dut.incr_sum, 1)
+    t.poke(dut.write_output, 1)
+    cycle()
+
+    # loop through test cases
+    for i in range(num_tests):
+        for j in range(2+CFG['num_chunks']):
+            if j < CFG['num_chunks']:
+                t.poke(dut.chunk, to_bv(test_cases[i][1][(j*CFG['chunk_width']):((j+1)*CFG['chunk_width'])]))
+                t.poke(dut.chunk_idx, j)
+            else:
+                t.poke(dut.chunk, 0)
+                t.poke(dut.chunk_idx, 0)
+
+            if j != (CFG['num_chunks']+1):
+                t.poke(dut.sample_ctl, 0)
+                t.poke(dut.write_output, 0)
+            else:
+                if i != (num_tests-1):
+                    t.poke(dut.pi_ctl, test_cases[i+1][0])
+                t.poke(dut.sample_ctl, 1)
+                t.poke(dut.write_output, 1)
+
+            if j != 1:
+                t.poke(dut.incr_sum, 1)
+            else:
+                t.poke(dut.incr_sum, 0)
+
+            cycle()
+
+        # gather results
+        test_cases[i].extend([t.get_value(dut.out_sgn), t.get_value(dut.out_mag)])
+
+    # run the simulation
+    t.compile_and_run(
+        target='system-verilog',
+        directory=BUILD_DIR,
+        simulator=simulator_name,
+        ext_srcs=[get_file('build/fpga_models/analog_slice/analog_slice.sv')],
+        inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],
+        ext_model_file=True,
+        disp_type='realtime',
+        dump_waveforms=True
+    )
+
+    # process the results
+    for k, (pi_ctl, all_bits, sgn_meas, mag_meas) in enumerate(test_cases):
+        # compute the expected ADC value
+        analog_sample = channel_model(slice_offset, pi_ctl, all_bits)
+        sgn_expct, mag_expct = adc_model(analog_sample)
+
+        # print measured and expected
+        print(f'Test case #{k}: slice_offset={slice_offset}, pi_ctl={pi_ctl}, all_bits={all_bits}')
+        print(f'[measured] sgn: {sgn_meas.value}, mag: {mag_meas.value}')
+        print(f'[expected] sgn: {sgn_expct}, mag: {mag_expct}, analog_sample: {analog_sample}')
+
+        # check result
+        check_adc_result(sgn_meas.value, mag_meas.value, sgn_expct, mag_expct)
+
+    # declare success
+    print('Success!')

--- a/tests/fpga_block_tests/analog_slice/test_analog_slice.py
+++ b/tests/fpga_block_tests/analog_slice/test_analog_slice.py
@@ -74,7 +74,7 @@ def check_adc_result(sgn_meas, mag_meas, sgn_expct, mag_expct):
         raise Exception('BAD!')
 
 @pytest.mark.parametrize('slice_offset', [0, 1, 2, 3])
-def test_chan_model(simulator_name, slice_offset, num_tests=100):
+def test_analog_slice(simulator_name, slice_offset, num_tests=100):
     # set seed for repeatable behavior
     random.seed(0)
 
@@ -175,8 +175,7 @@ def test_chan_model(simulator_name, slice_offset, num_tests=100):
         ext_srcs=[get_file('build/fpga_models/analog_slice/analog_slice.sv')],
         inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],
         ext_model_file=True,
-        disp_type='realtime',
-        dump_waveforms=True
+        disp_type='realtime'
     )
 
     # process the results

--- a/tests/fpga_block_tests/chan_model/test_chan_model.py
+++ b/tests/fpga_block_tests/chan_model/test_chan_model.py
@@ -13,12 +13,15 @@ from msdsl import get_msdsl_header
 from dragonphy import get_file, Filter
 
 BUILD_DIR = Path(__file__).resolve().parent / 'build'
-SIMULATOR = 'vivado'
 
 DELTA = 100e-9
 TPER = 1e-6
 
-def test_chan_model():
+def test_chan_model(simulator_name):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
     # declare circuit
     class dut(m.Circuit):
         name = 'test_chan_model'
@@ -146,7 +149,7 @@ def test_chan_model():
     t.compile_and_run(
         target='system-verilog',
         directory=BUILD_DIR,
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=[get_file('build/fpga_models/chan_core/chan_core.sv'),
                   get_file('tests/fpga_block_tests/chan_model/test_chan_model.sv')],
         inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],

--- a/tests/fpga_block_tests/clk_delay/test_clk_delay.py
+++ b/tests/fpga_block_tests/clk_delay/test_clk_delay.py
@@ -15,7 +15,6 @@ from msdsl import get_msdsl_header
 from dragonphy import get_file, Filter
 
 BUILD_DIR = Path(__file__).resolve().parent / 'build'
-SIMULATOR = 'vivado'
 
 # DUT options
 N_BITS = 9
@@ -28,7 +27,11 @@ TCLK = 1e-6
 DELTA = 0.1*TCLK
 
 @pytest.mark.parametrize('float_real', [False, True])
-def test_clk_delay(float_real):
+def test_clk_delay(simulator_name, float_real):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
     # declare circuit
     class dut(m.Circuit):
         name = 'test_clk_delay'
@@ -128,7 +131,7 @@ def test_clk_delay(float_real):
     t.compile_and_run(
         target='system-verilog',
         directory=BUILD_DIR,
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=[get_file('build/fpga_models/clk_delay_core/clk_delay_core.sv'),
                   get_file('tests/fpga_block_tests/clk_delay/test_clk_delay.sv')],
         inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],

--- a/tests/fpga_block_tests/osc_model/test_osc_model.py
+++ b/tests/fpga_block_tests/osc_model/test_osc_model.py
@@ -15,7 +15,6 @@ from msdsl import get_msdsl_header
 from dragonphy import get_file, Filter
 
 BUILD_DIR = Path(__file__).resolve().parent / 'build'
-SIMULATOR = 'vivado'
 
 # DUT options
 T_PER = 1e-9
@@ -26,7 +25,11 @@ TCLK = 1e-6
 DELTA = 0.1*TCLK
 
 @pytest.mark.parametrize('float_real', [False, True])
-def test_osc_model(float_real):
+def test_osc_model(simulator_name, float_real):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
     # declare circuit
     class dut(m.Circuit):
         name = 'test_osc_model'
@@ -113,7 +116,7 @@ def test_osc_model(float_real):
     t.compile_and_run(
         target='system-verilog',
         directory=BUILD_DIR,
-        simulator=SIMULATOR,
+        simulator=simulator_name,
         ext_srcs=[get_file('build/fpga_models/osc_model_core/osc_model_core.sv'),
                   get_file('tests/fpga_block_tests/osc_model/test_osc_model.sv')],
         inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],

--- a/tests/fpga_system_tests/emu/test_emu.py
+++ b/tests/fpga_system_tests/emu/test_emu.py
@@ -30,7 +30,7 @@ def test_1(board_name, emu_clk_freq):
     src_cfg.add_verilog_sources([get_file('build/cpu_models/jtag/jtag_reg_pack.sv')], fileset='sim')
 
     # Verilog Sources
-    deps = get_deps_fpga_emu(impl_file=(THIS_DIR / 'tb.sv'))
+    deps = get_deps_fpga_emu(impl_file=(THIS_DIR / 'tb.sv'), override={'analog_core': 'chip_src'})
     deps = [dep for dep in deps if Path(dep).stem != 'tb']  # anasymod already includes tb.sv
     src_cfg.add_verilog_sources(deps)
     src_cfg.add_verilog_sources([THIS_DIR / 'sim_ctrl.sv'], fileset='sim')

--- a/tests/fpga_system_tests/emu/test_emu.py
+++ b/tests/fpga_system_tests/emu/test_emu.py
@@ -11,7 +11,6 @@ from dragonphy import *
 from dragonphy.git_util import get_git_hash_short
 
 THIS_DIR = Path(__file__).resolve().parent
-SIMULATOR = 'vivado'
 
 def test_1(board_name, emu_clk_freq):
     # Write project config
@@ -56,9 +55,13 @@ def test_1(board_name, emu_clk_freq):
     # "models" directory has to exist
     (THIS_DIR / 'build' / 'models').mkdir(exist_ok=True, parents=True)
 
-def test_2():
+def test_2(simulator_name):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
     # run simulation
-    ana = Analysis(input=str(THIS_DIR), simulator_name=SIMULATOR)
+    ana = Analysis(input=str(THIS_DIR), simulator_name=simulator_name)
     ana.set_target(target_name='sim')
     ana.simulate(convert_waveform=False)
 

--- a/tests/fpga_system_tests/emu_macro/.gitignore
+++ b/tests/fpga_system_tests/emu_macro/.gitignore
@@ -1,0 +1,3 @@
+build
+source.yaml
+prj.yaml

--- a/tests/fpga_system_tests/emu_macro/clks.yaml
+++ b/tests/fpga_system_tests/emu_macro/clks.yaml
@@ -1,0 +1,11 @@
+derived_clks:
+  tb_emu_io:
+    abspath: 'tb_i'
+    emu_clk: 'emu_clk'
+    emu_rst: 'emu_rst'
+  iacore_clk_adc:
+    abspath: 'tb_i.top_i.iacore'
+    emu_clk: 'emu_clk'
+    emu_rst: 'emu_rst'
+    gated_clk_req: 'clk_adc_val'
+    gated_clk: 'clk_adc_i'

--- a/tests/fpga_system_tests/emu_macro/main.c
+++ b/tests/fpga_system_tests/emu_macro/main.c
@@ -139,6 +139,23 @@ u32 read_id() {
     return shift_dr(0, 32);
 }
 
+enum cmd_t {
+    RESET,
+    INIT,
+    EXIT,
+    ID,
+    SIR,
+    SDR,
+    SET_RSTB,
+    SET_EMU_RST,
+    SET_SLEEP,
+    SET_TDI,
+    SET_TCK,
+    SET_TMS,
+    SET_TRST_N,
+    GET_TDO
+} cmd;
+
 int main() {
     // character buffering
     u32 idx = 0;
@@ -146,7 +163,6 @@ int main() {
     char buf [32];
     
     // command processing;
-    u32 cmd;
     u32 arg1;
     u32 arg2;
     u32 nargs = 0;
@@ -167,42 +183,75 @@ int main() {
                 buf[idx++] = '\0';
                 if (nargs == 0) {
                     if (strcmp(buf, "RESET") == 0) {
+                        cmd = RESET;
                         do_reset();
                         nargs = 0;
                     } else if (strcmp(buf, "INIT") == 0) {
+                        cmd = INIT;
                         do_init();
                         nargs = 0;
                     } else if (strcmp(buf, "EXIT") == 0) {
+                        cmd = EXIT;
                         return 0;
                     } else if (strcmp(buf, "ID") == 0) {
+                        cmd = ID;
                         xil_printf("%lu\r\n", read_id());
+                        nargs = 0;
                     } else if (strcmp(buf, "SIR") == 0) {
-                        cmd = 1;
+                        cmd = SIR;
                         nargs++;
                     } else if (strcmp(buf, "SDR") == 0) {
-                        cmd = 2;
+                        cmd = SDR;
                         nargs++;
                     } else if (strcmp(buf, "SET_RSTB") == 0) {
-                        cmd = 3;
+                        cmd = SET_RSTB;
                         nargs++;
                     } else if (strcmp(buf, "SET_EMU_RST") == 0) {
-                        cmd = 4;
+                        cmd = SET_EMU_RST;
                         nargs++;
                     } else if (strcmp(buf, "SET_SLEEP") == 0) {
-                        cmd = 5;
+                        cmd = SET_SLEEP;
                         nargs++;
+                    } else if (strcmp(buf, "SET_TDI") == 0) {
+                        cmd = SET_TDI;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_TCK") == 0) {
+                        cmd = SET_TCK;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_TMS") == 0) {
+                        cmd = SET_TMS;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_TRST_N") == 0) {
+                        cmd = SET_TRST_N;
+                        nargs++;
+                    } else if (strcmp(buf, "GET_TDO") == 0) {
+                        cmd = GET_TDO;
+                        xil_printf("%lu\r\n", get_tdo());
+                        nargs = 0;
                     } else {
-	                xil_printf("ERROR: Unknown command\r\n");
+	                    xil_printf("ERROR: Unknown command\r\n");
 		            }
                 } else if (nargs == 1) {
                     sscanf(buf, "%lu", &arg1);
-                    if (cmd == 3) {
+                    if (cmd == SET_RSTB) {
                         set_rstb(arg1);
                         nargs=0;
-                    } else if (cmd == 4) {
+                    } else if (cmd == SET_EMU_RST) {
                         set_emu_rst(arg1);
                         nargs=0;
-                    } else if (cmd == 5) {
+                    } else if (cmd == SET_TDI) {
+                        set_tdi(arg1);
+                        nargs=0;
+                    } else if (cmd == SET_TCK) {
+                        set_tck(arg1);
+                        nargs=0;
+                    } else if (cmd == SET_TMS) {
+                        set_tms(arg1);
+                        nargs=0;
+                    } else if (cmd == SET_TRST_N) {
+                        set_trst_n(arg1);
+                        nargs=0;
+                    } else if (cmd == SET_SLEEP) {
                         sleep_time = arg1;
                         nargs=0;
                     } else {
@@ -210,9 +259,9 @@ int main() {
                     }
                 } else if (nargs == 2) {
                     sscanf(buf, "%lu", &arg2);
-                    if (cmd == 1) {
+                    if (cmd == SIR) {
                         shift_ir(arg1, arg2);
-                    } else if (cmd == 2) {
+                    } else if (cmd == SDR) {
                         xil_printf("%lu\r\n", shift_dr(arg1, arg2));
                     }
                     nargs = 0;

--- a/tests/fpga_system_tests/emu_macro/main.c
+++ b/tests/fpga_system_tests/emu_macro/main.c
@@ -1,0 +1,229 @@
+#include "gpio_funcs.h"
+#include <stdio.h>
+#include <string.h>
+#include "sleep.h"
+
+u32 sleep_time = 20;
+
+void cycle() {
+    // min usleep value is "5" when emu_clk_freq is 5 MHz
+    usleep(sleep_time);
+    set_tck(1);
+    usleep(sleep_time);
+    set_tck(0);
+    usleep(sleep_time);
+}
+
+void do_init() {
+   // emulator controls
+   set_emu_rst(1);
+   set_emu_ctrl_mode(0);
+   set_emu_ctrl_data(0);
+   set_emu_dec_thr(0);
+
+   // JTAG-specific
+   set_tdi(0);
+   set_tck(0);
+   set_tms(1);
+   set_trst_n(0);
+
+   // Other signals
+   set_rstb(0);
+}
+
+void do_reset() {
+    // initialize JTAG signals
+    set_tdi(0);
+    set_tck(0);
+    set_tms(1);
+    set_trst_n(0);
+    cycle();
+
+    // de-assert reset
+    set_trst_n(1);
+    cycle();
+
+    // go to the IDLE state
+    set_tms(1);
+    cycle();
+    for (u32 i=0; i<10; i++){
+    	cycle();
+    }
+
+    set_tms(0);
+    cycle();
+}
+
+void shift_ir (u32 inst_in, u32 length) {
+    // Move to Select-DR-Scan state
+    set_tms(1);
+    cycle();
+
+    // Move to Select-IR-Scan state
+    set_tms(1);
+    cycle();
+
+    // Move to Capture IR state
+    set_tms(0);
+    cycle();
+
+    // Move to Shift-IR state
+    set_tms(0);
+    cycle();
+
+    // Remain in Shift-IR state and shift in inst_in.
+    // Observe the TDO signal to read the x_inst_out
+    for (u32 i=0; i<(length-1); i++){
+        set_tdi((inst_in >> i) & 1);
+        cycle();
+    }
+
+    // Shift in the last bit and switch to Exit1-IR state
+    set_tdi((inst_in >> (length - 1)) & 1);
+    set_tms(1);
+    cycle();
+
+    // Move to Update-IR state
+    set_tms(1);
+    cycle();
+
+    // Move to Run-Test/Idle state
+    set_tms(0);
+    cycle();
+    cycle();
+}
+
+u32 shift_dr (u32 data_in, u32 length) {
+	// Move to Select-DR-Scan state
+    set_tms(1);
+    cycle();
+
+    // Move to Capture-DR state
+    set_tms(0);
+    cycle();
+
+    // Move to Shift-DR state
+    set_tms(0);
+    cycle();
+
+    // Remain in Shift-DR state and shift in data_in.
+	// Observe the TDO signal to read the data_out
+    u32 retval = 0;
+    for (u32 i=0; i<(length-1); i++){
+        set_tdi((data_in >> i) & 1);
+        retval |= (get_tdo() << i);
+        cycle();
+    }
+
+    // Shift in the last bit and switch to Exit1-DR state
+    set_tdi((data_in >> (length - 1)) & 1);
+    retval |= (get_tdo() << (length-1));
+    set_tms(1);
+    cycle();
+
+    // Move to Update-DR state
+    set_tms(1);
+    cycle();
+
+    // Move to Run-Test/Idle state
+    set_tms(0);
+    cycle();
+    cycle();
+
+    // Return result
+    return retval;
+}
+
+u32 read_id() {
+    shift_ir(1, 5);
+    return shift_dr(0, 32);
+}
+
+int main() {
+    // character buffering
+    u32 idx = 0;
+    char rcv;
+    char buf [32];
+    
+    // command processing;
+    u32 cmd;
+    u32 arg1;
+    u32 arg2;
+    u32 nargs = 0;
+
+    if (init_GPIO() != 0) {
+        xil_printf("GPIO Initialization Failed\r\n");
+        return XST_FAILURE;
+    }
+
+    do_init();
+    do_reset();
+    
+    while (1) {
+        rcv = inbyte();
+        if ((rcv == ' ') || (rcv == '\t') || (rcv == '\r') || (rcv == '\n')) {
+            // whitespace
+            if (idx > 0) {
+                buf[idx++] = '\0';
+                if (nargs == 0) {
+                    if (strcmp(buf, "RESET") == 0) {
+                        do_reset();
+                        nargs = 0;
+                    } else if (strcmp(buf, "INIT") == 0) {
+                        do_init();
+                        nargs = 0;
+                    } else if (strcmp(buf, "EXIT") == 0) {
+                        return 0;
+                    } else if (strcmp(buf, "ID") == 0) {
+                        xil_printf("%lu\r\n", read_id());
+                    } else if (strcmp(buf, "SIR") == 0) {
+                        cmd = 1;
+                        nargs++;
+                    } else if (strcmp(buf, "SDR") == 0) {
+                        cmd = 2;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_RSTB") == 0) {
+                        cmd = 3;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_EMU_RST") == 0) {
+                        cmd = 4;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_SLEEP") == 0) {
+                        cmd = 5;
+                        nargs++;
+                    } else {
+	                xil_printf("ERROR: Unknown command\r\n");
+		            }
+                } else if (nargs == 1) {
+                    sscanf(buf, "%lu", &arg1);
+                    if (cmd == 3) {
+                        set_rstb(arg1);
+                        nargs=0;
+                    } else if (cmd == 4) {
+                        set_emu_rst(arg1);
+                        nargs=0;
+                    } else if (cmd == 5) {
+                        sleep_time = arg1;
+                        nargs=0;
+                    } else {
+                        nargs++;
+                    }
+                } else if (nargs == 2) {
+                    sscanf(buf, "%lu", &arg2);
+                    if (cmd == 1) {
+                        shift_ir(arg1, arg2);
+                    } else if (cmd == 2) {
+                        xil_printf("%lu\r\n", shift_dr(arg1, arg2));
+                    }
+                    nargs = 0;
+                }  
+            }
+            idx = 0;
+        } else {
+            // load next character
+            buf[idx++] = rcv;
+        }
+    }
+
+    return 0;
+}

--- a/tests/fpga_system_tests/emu_macro/main.c
+++ b/tests/fpga_system_tests/emu_macro/main.c
@@ -146,6 +146,7 @@ enum cmd_t {
     ID,
     SIR,
     SDR,
+    QSDR, // "quiet" SDR -- does not print anything
     SET_RSTB,
     SET_EMU_RST,
     SET_SLEEP,
@@ -202,6 +203,9 @@ int main() {
                         nargs++;
                     } else if (strcmp(buf, "SDR") == 0) {
                         cmd = SDR;
+                        nargs++;
+                    } else if (strcmp(buf, "QSDR") == 0) {
+                        cmd = QSDR;
                         nargs++;
                     } else if (strcmp(buf, "SET_RSTB") == 0) {
                         cmd = SET_RSTB;
@@ -263,6 +267,8 @@ int main() {
                         shift_ir(arg1, arg2);
                     } else if (cmd == SDR) {
                         xil_printf("%lu\r\n", shift_dr(arg1, arg2));
+                    } else if (cmd == QSDR) {
+                        shift_dr(arg1, arg2);
                     }
                     nargs = 0;
                 }  

--- a/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
@@ -1,0 +1,196 @@
+`timescale 1s/1fs
+
+`ifndef GIT_HASH
+    `define GIT_HASH 0
+`endif
+
+`define FORCE_JTAG(name, value) force top.tb_i.top_i.idcore.jtag_i.rjtag_intf_i.``name`` = ``value``
+`define GET_JTAG(name) top.tb_i.top_i.idcore.jtag_i.rjtag_intf_i.``name``
+
+module sim_ctrl(
+    output reg rstb=1'b0,
+    output reg tdi=1'b0,
+    output reg tck=1'b0,
+    output reg tms=1'b1,
+    output reg trst_n=1'b0,
+    output reg dump_start=1'b0,
+    input wire tdo
+);
+	import const_pack::*;
+    import jtag_reg_pack::*;
+
+    import ffe_gpack::length;
+    import ffe_gpack::weight_precision;
+    import constant_gpack::channel_width;
+
+    // calculate FFE coefficients
+    localparam real dt=1.0/(16.0e9);
+    localparam real tau=25.0e-12;
+    localparam integer coeff0 = 128.0/(1.0-$exp(-dt/tau));
+    localparam integer coeff1 = -128.0*$exp(-dt/tau)/(1.0-$exp(-dt/tau));
+
+    logic [Nadc-1:0] tmp_ext_pfd_offset [Nti-1:0];
+    logic [Npi-1:0] tmp_ext_pi_ctl_offset [Nout-1:0];
+
+    integer loop_var, loop_var2;
+    longint err_bits, total_bits;
+
+    logic [ffe_gpack::shift_precision-1:0] tmp_ffe_shift [constant_gpack::channel_width-1:0];
+
+    // for loading one FFE weight with specified depth and width
+    task load_weight(
+        input logic [$clog2(length)-1:0] d_idx,
+        logic [$clog2(channel_width)-1:0] w_idx,
+        logic [weight_precision-1:0] value
+    );
+        $display("Loading weight d_idx=%0d, w_idx=%0d with value %0d", d_idx, w_idx, value);
+        `FORCE_JTAG(wme_ffe_inst, {1'b0, w_idx, d_idx});
+        `FORCE_JTAG(wme_ffe_data, value);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+        `FORCE_JTAG(wme_ffe_exec, 1);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+        `FORCE_JTAG(wme_ffe_exec, 0);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+    endtask
+
+    initial begin
+        // wait for emulator reset to complete
+        $display("Waiting for emulator reset to complete...");
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // release external reset signals
+        rstb = 1'b1;
+        trst_n = 1'b1;
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Soft reset sequence
+        $display("Soft reset sequence...");
+        `FORCE_JTAG(int_rstb, 1);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+        `FORCE_JTAG(en_inbuf, 1);
+		#((10.0/(`EMU_CLK_FREQ))*1s);
+        `FORCE_JTAG(en_gf, 1);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+        `FORCE_JTAG(en_v2t, 1);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Set up the PFD offset
+        $display("Setting up the PFD offset...");
+        for (int idx=0; idx<Nti; idx=idx+1) begin
+            tmp_ext_pfd_offset[idx] = 0;
+        end
+        `FORCE_JTAG(ext_pfd_offset, tmp_ext_pfd_offset);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Select the PRBS checker data source
+        $display("Select the PRBS checker data source");
+        `FORCE_JTAG(sel_prbs_mux, 2'b01); // 2'b00: ADC, 2'b01: FFE
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Release the PRBS checker from reset
+        $display("Release the PRBS tester from reset");
+        `FORCE_JTAG(prbs_rstb, 1);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Set up the FFE
+        for (loop_var=0; loop_var<Nti; loop_var=loop_var+1) begin
+            for (loop_var2=0; loop_var2<ffe_gpack::length; loop_var2=loop_var2+1) begin
+                if (loop_var2 == 0) begin
+                    // The argument order for load() is depth, width, value
+                    load_weight(loop_var2, loop_var, coeff0);
+                end else if (loop_var2 == 1) begin
+                    load_weight(loop_var2, loop_var, coeff1);
+                end else begin
+                    load_weight(loop_var2, loop_var, 0);
+                end
+            end
+            tmp_ffe_shift[loop_var] = 7;
+        end
+        `FORCE_JTAG(ffe_shift, tmp_ffe_shift);
+
+        // Configure the CDR offsets
+        $display("Setting up the CDR offset...");
+        tmp_ext_pi_ctl_offset[0] =   0;
+        tmp_ext_pi_ctl_offset[1] = 128;
+        tmp_ext_pi_ctl_offset[2] = 256;
+        tmp_ext_pi_ctl_offset[3] = 384;
+        `FORCE_JTAG(ext_pi_ctl_offset, tmp_ext_pi_ctl_offset);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+        `FORCE_JTAG(en_ext_max_sel_mux, 1);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Configure the retimer
+        `FORCE_JTAG(retimer_mux_ctrl_1, 16'hFFFF);
+        `FORCE_JTAG(retimer_mux_ctrl_2, 16'hFFFF);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Configure the CDR
+        $display("Configuring the CDR...");
+        `FORCE_JTAG(Kp, 18);
+        `FORCE_JTAG(Ki, 0);
+        `FORCE_JTAG(invert, 1);
+        `FORCE_JTAG(en_freq_est, 0);
+        `FORCE_JTAG(en_ext_pi_ctl, 0);
+        `FORCE_JTAG(sel_inp_mux, 1); // "0": use ADC output, "1": use FFE output
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Toggle the en_v2t signal to re-initialize the V2T ordering
+        $display("Toggling en_v2t...");
+        `FORCE_JTAG(en_v2t, 0);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+        `FORCE_JTAG(en_v2t, 1);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Wait for PRBS checker to lock
+		$display("Waiting for PRBS checker to lock...");
+		for (loop_var=0; loop_var<50; loop_var=loop_var+1) begin
+		    $display("Interval %0d/50", loop_var);
+		    #((50.0/(`EMU_CLK_FREQ))*1s);
+		end
+
+        // Run the PRBS tester
+        $display("Running the PRBS tester");
+        `FORCE_JTAG(prbs_checker_mode, 2);
+        for (loop_var=0; loop_var<100; loop_var=loop_var+1) begin
+		    $display("Interval %0d/100", loop_var);
+		    #((50.0/(`EMU_CLK_FREQ))*1s);
+		end
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // Get results
+        `FORCE_JTAG(prbs_checker_mode, 3);
+        #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        err_bits = 0;
+        err_bits |= `GET_JTAG(prbs_err_bits_upper);
+        err_bits <<= 32;
+        err_bits |= `GET_JTAG(prbs_err_bits_lower);
+
+        total_bits = 0;
+        total_bits |= `GET_JTAG(prbs_total_bits_upper);
+        total_bits <<= 32;
+        total_bits |= `GET_JTAG(prbs_total_bits_lower);
+
+        // Print results
+        $display("err_bits: %0d", err_bits);
+        $display("total_bits: %0d", total_bits);
+
+        // Check results
+
+        if (!(total_bits >= 500)) begin
+            $error("Not enough bits transmitted");
+        end else begin
+            $display("Number of bits transmitted is OK");
+        end
+
+        if (!(err_bits == 0)) begin
+            $error("Bit error detected");
+        end else begin
+            $display("No bit errors detected");
+        end
+
+		// Finish test
+		$display("Test complete.");
+		$finish;
+    end
+endmodule

--- a/tests/fpga_system_tests/emu_macro/simctrl.yaml
+++ b/tests/fpga_system_tests/emu_macro/simctrl.yaml
@@ -1,0 +1,41 @@
+digital_ctrl_inputs:
+  rstb:
+    abspath: 'tb_i.rstb'
+    width: 1
+    init_value: 0
+  dump_start:
+    abspath: 'tb_i.dump_start'
+    width: 1
+    init_value: 0
+  tdi:
+    abspath: 'tb_i.tdi'
+    width: 1
+    init_value: 0
+  tck:
+    abspath: 'tb_i.tck'
+    width: 1
+    init_value: 0
+  tms:
+    abspath: 'tb_i.tms'
+    width: 1
+    init_value: 1
+  trst_n:
+    abspath: 'tb_i.trst_n'
+    width: 1
+    init_value: 0
+digital_ctrl_outputs:
+  tdo:
+    abspath: 'tb_i.tdo'
+    width: 1
+digital_probes:
+  ctl_pi_0:
+    abspath: 'tb_i.top_i.iacore.ctl_pi[0]'
+    width: 9
+  adcout_unfolded_0:
+    abspath: 'tb_i.top_i.idcore.adcout_unfolded[0]'
+    width: 8
+    signed: 1
+  estimated_bits_0:
+    abspath: 'tb_i.top_i.idcore.estimated_bits[0]'
+    width: 10
+    signed: 1

--- a/tests/fpga_system_tests/emu_macro/tb.sv
+++ b/tests/fpga_system_tests/emu_macro/tb.sv
@@ -1,0 +1,98 @@
+module tb;
+    ///////////////
+    // Constants //
+    ///////////////
+
+    import const_pack::Nti;
+
+    //////////////////
+    // External IOs //
+    //////////////////
+
+    (* dont_touch = "true" *) logic rstb;
+    (* dont_touch = "true" *) logic dump_start;
+
+    (* dont_touch = "true" *) logic tdi;
+	(* dont_touch = "true" *) logic tdo;
+	(* dont_touch = "true" *) logic tck;
+	(* dont_touch = "true" *) logic tms;
+	(* dont_touch = "true" *) logic trst_n;
+
+    ////////////////////
+	// JTAG Interface //
+	////////////////////
+
+	jtag_intf jtag_intf_i ();
+	assign jtag_intf_i.phy_tdi = tdi;
+    assign tdo = jtag_intf_i.phy_tdo;
+    assign jtag_intf_i.phy_tck = tck;
+    assign jtag_intf_i.phy_tms = tms;
+    assign jtag_intf_i.phy_trst_n = trst_n;
+
+    ////////////////////
+	//  Emulator I/O  //
+	////////////////////
+
+    (* dont_touch = "true" *) logic emu_rst;
+    (* dont_touch = "true" *) logic emu_clk;
+
+    ////////////////
+	// Top module //
+	////////////////
+
+    logic [(Nti-1):0] data_rx_i;
+
+	(* dont_touch = "true" *) dragonphy_top top_i (
+	    // analog inputs
+		.ext_rx_inp(data_rx_i),
+		.ext_rx_inn(0),
+
+        // reset
+        .ext_rstb(rstb),
+
+        // SRAM dump
+        .ext_dump_start(dump_start),
+
+        // JTAG
+		.jtag_intf_i(jtag_intf_i)
+
+		// other I/O not used..
+	);
+
+    //////////
+    // PRBS //
+    //////////
+
+    logic [3:0] counter;
+    logic prbs_cke;
+
+    assign prbs_cke = (counter == 5) ? 1'b1 : 1'b0;
+
+    always @(posedge emu_clk) begin
+        if (emu_rst) begin
+            counter <= 0;
+        end else if (counter == 5) begin
+            counter <= 0;
+        end else begin
+            counter <= counter + 1;
+        end
+    end
+
+    genvar i;
+    generate
+        for(i=0; i<Nti; i=i+1) begin
+            prbs_generator_syn #(
+                .n_prbs(32)
+            ) prbs_generator_syn_i (
+                .clk(emu_clk),
+                .rst(emu_rst),
+                .cke(prbs_cke),
+                .init_val(i+1),
+                .eqn(32'b00000000000000000000000001100000),
+                .inj_err(1'b0),
+                .inv_chicken(2'b00),
+                .out(data_rx_i[i])
+            );
+        end
+    endgenerate
+endmodule

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -293,7 +293,8 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur):
 
     # Configure the CDR
     print('Configuring the CDR...')
-    write_tc_reg('Kp', 15)
+    write_tc_reg('cdr_rstb', 0)
+    write_tc_reg('Kp', 18)
     write_tc_reg('Ki', 0)
     write_tc_reg('invert', 1)
     write_tc_reg('en_freq_est', 0)
@@ -305,8 +306,11 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur):
     write_tc_reg('en_v2t', 0)
     write_tc_reg('en_v2t', 1)
 
-    # Wait for CDR to lock
-    print('Wait for PRBS checker to lock')
+    # Release the CDR from reset, then wait for it to lock
+    # TODO: explore why it is not sufficient to pulse cdr_rstb low here
+    # (i.e., seems that it must be set to zero while configuring CDR parameters
+    print('Wait for the CDR to lock')
+    write_tc_reg('cdr_rstb', 1)
     time.sleep(1.0)
 
     # Run PRBS test.  In order to get a conservative estimate for the throughput, the

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -23,9 +23,9 @@ def test_1(board_name, emu_clk_freq):
     src_cfg = AnasymodSourceConfig()
 
     # JTAG-related
-    #src_cfg.add_edif_files([os.environ['TAP_CORE_LOC']], fileset='fpga')
-    #src_cfg.add_verilog_sources([get_file('vlog/fpga_models/jtag/tap_core.sv')], fileset='fpga')
-    #src_cfg.add_verilog_sources([get_file('vlog/fpga_models/jtag/DW_tap.sv')], fileset='fpga')
+    src_cfg.add_edif_files([os.environ['TAP_CORE_LOC']], fileset='fpga')
+    src_cfg.add_verilog_sources([get_file('vlog/fpga_models/jtag/tap_core.sv')], fileset='fpga')
+    src_cfg.add_verilog_sources([get_file('vlog/fpga_models/jtag/DW_tap.sv')], fileset='fpga')
     src_cfg.add_verilog_sources([os.environ['DW_TAP']], fileset='sim')
     src_cfg.add_verilog_sources([get_file('build/cpu_models/jtag/jtag_reg_pack.sv')], fileset='sim')
 
@@ -41,9 +41,7 @@ def test_1(board_name, emu_clk_freq):
 
     # Verilog Defines
     src_cfg.add_defines({'VIVADO': None})
-    src_cfg.add_defines({'DT_EXPONENT': -46})  # TODO: move to DT_SCALE
     src_cfg.add_defines({'GIT_HASH': str(get_git_hash_short())}, fileset='sim')
-    src_cfg.add_defines({'LONG_WIDTH_REAL': 32})
 
     # Firmware
     src_cfg.add_firmware_files([THIS_DIR / 'main.c'])

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -1,0 +1,353 @@
+import os
+import serial
+import time
+import json
+import re
+from pathlib import Path
+from math import exp, ceil, log2
+
+from anasymod.analysis import Analysis
+from dragonphy import *
+from dragonphy.git_util import get_git_hash_short
+
+THIS_DIR = Path(__file__).resolve().parent
+
+def test_1(board_name, emu_clk_freq):
+    # Write project config
+    prj = AnasymodProjectConfig()
+    prj.set_board_name(board_name)
+    prj.set_emu_clk_freq(emu_clk_freq)
+    prj.write_to_file(THIS_DIR / 'prj.yaml')
+
+    # Build up a configuration of source files for the project
+    src_cfg = AnasymodSourceConfig()
+
+    # JTAG-related
+    #src_cfg.add_edif_files([os.environ['TAP_CORE_LOC']], fileset='fpga')
+    #src_cfg.add_verilog_sources([get_file('vlog/fpga_models/jtag/tap_core.sv')], fileset='fpga')
+    #src_cfg.add_verilog_sources([get_file('vlog/fpga_models/jtag/DW_tap.sv')], fileset='fpga')
+    src_cfg.add_verilog_sources([os.environ['DW_TAP']], fileset='sim')
+    src_cfg.add_verilog_sources([get_file('build/cpu_models/jtag/jtag_reg_pack.sv')], fileset='sim')
+
+    # Verilog Sources
+    deps = get_deps_fpga_emu(impl_file=(THIS_DIR / 'tb.sv'))
+    deps = [dep for dep in deps if Path(dep).stem != 'tb']  # anasymod already includes tb.sv
+    src_cfg.add_verilog_sources(deps)
+    src_cfg.add_verilog_sources([THIS_DIR / 'sim_ctrl.sv'], fileset='sim')
+
+    # Verilog Headers
+    header_file_list = [get_file('inc/fpga/iotype.sv')]
+    src_cfg.add_verilog_headers(header_file_list)
+
+    # Verilog Defines
+    src_cfg.add_defines({'VIVADO': None})
+    src_cfg.add_defines({'DT_EXPONENT': -46})  # TODO: move to DT_SCALE
+    src_cfg.add_defines({'GIT_HASH': str(get_git_hash_short())}, fileset='sim')
+    src_cfg.add_defines({'LONG_WIDTH_REAL': 32})
+
+    # Firmware
+    src_cfg.add_firmware_files([THIS_DIR / 'main.c'])
+
+    # Write source config
+    # TODO: interact directly with anasymod library rather than through config files
+    src_cfg.write_to_file(THIS_DIR / 'source.yaml')
+
+    # "models" directory has to exist
+    (THIS_DIR / 'build' / 'models').mkdir(exist_ok=True, parents=True)
+
+def test_2(simulator_name):
+    # set defaults
+    if simulator_name is None:
+        simulator_name = 'vivado'
+
+    # run simulation
+    ana = Analysis(input=str(THIS_DIR), simulator_name=simulator_name)
+    ana.set_target(target_name='sim')
+    ana.simulate(convert_waveform=False)
+
+def test_3():
+    # build bitstream
+    ana = Analysis(input=str(THIS_DIR))
+    ana.set_target(target_name='fpga')
+    ana.build()
+
+def test_4():
+    # build ELF
+    ana = Analysis(input=str(THIS_DIR))
+    ana.set_target(target_name='fpga')
+    ana.build_firmware()
+
+def test_5():
+    # download program
+    ana = Analysis(input=str(THIS_DIR))
+    ana.set_target(target_name='fpga')
+    ana.program_firmware()
+
+def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur):
+    jtag_inst_width = 5
+    sc_bus_width = 32
+    sc_addr_width = 14
+
+    tc_bus_width = 32
+    tc_addr_width = 14
+
+    sc_op_width = 2
+    tc_op_width = 2
+
+    sc_cfg_data = 8
+    sc_cfg_inst = 9
+    sc_cfg_addr = 10
+    tc_cfg_data = 12
+    tc_cfg_inst = 13
+    tc_cfg_addr = 14
+
+    read = 1
+    write = 2
+
+    reg_list = json.load(open(get_file('build/all/jtag/reg_list.json'), 'r'))
+    reg_dict = {elem['name']: elem['addresses'] for elem in reg_list}
+    arr_pat = re.compile(r'([a-zA-Z_0-9]+)+\[(\d+)\]')
+    def get_reg_addr(name):
+        m = arr_pat.match(name)
+        if m:
+            name = m.groups()[0]
+            index = int(m.groups()[1])
+            return reg_dict[name][index]
+        else:
+            return reg_dict[name]
+
+    # connect to the CPU
+    print('Connecting to the CPU...')
+    ser = serial.Serial(
+        port=ser_port,
+        baudrate=115200
+    )
+
+    # functions
+    def do_reset():
+        ser.write('RESET\n'.encode('utf-8'))
+
+    def do_init():
+        ser.write('INIT\n'.encode('utf-8'))
+
+    def set_emu_rst(val):
+        ser.write(f'SET_EMU_RST {val}\n'.encode('utf-8'))
+
+    def set_rstb(val):
+        ser.write(f'SET_RSTB {val}\n'.encode('utf-8'))
+
+    def set_sleep(val):
+        ser.write(f'SET_SLEEP {val}\n'.encode('utf-8'))
+
+    def shift_ir(val, width):
+        ser.write(f'SIR {val} {width}\n'.encode('utf-8'))
+
+    def shift_dr(val, width):
+        ser.write(f'SDR {val} {width}\n'.encode('utf-8'))
+        return int(ser.readline().strip())
+
+    def write_tc_reg(name, val):
+        # specify address
+        shift_ir(tc_cfg_addr, jtag_inst_width)
+        shift_dr(get_reg_addr(name), tc_addr_width)
+
+        # send data
+        shift_ir(tc_cfg_data, jtag_inst_width)
+        shift_dr(val, tc_bus_width)
+
+        # specify "WRITE" operation
+        shift_ir(tc_cfg_inst, jtag_inst_width)
+        shift_dr(write, tc_op_width)
+
+    def write_sc_reg(name, val):
+        # specify address
+        shift_ir(sc_cfg_addr, jtag_inst_width)
+        shift_dr(get_reg_addr(name), sc_addr_width)
+
+        # send data
+        shift_ir(sc_cfg_data, jtag_inst_width)
+        shift_dr(val, sc_bus_width)
+
+        # specify "WRITE" operation
+        shift_ir(sc_cfg_inst, jtag_inst_width)
+        shift_dr(write, sc_op_width)
+
+    def read_tc_reg(name):
+        # specify address
+        shift_ir(tc_cfg_addr, jtag_inst_width)
+        shift_dr(get_reg_addr(name), tc_addr_width)
+
+        # specify "READ" operation
+        shift_ir(tc_cfg_inst, jtag_inst_width)
+        shift_dr(read, tc_op_width)
+
+        # get data
+        shift_ir(tc_cfg_data, jtag_inst_width)
+        return shift_dr(0, tc_bus_width)
+
+    def read_sc_reg(name):
+        # specify address
+        shift_ir(sc_cfg_addr, jtag_inst_width)
+        shift_dr(get_reg_addr(name), sc_addr_width)
+
+        # specify "READ" operation
+        shift_ir(sc_cfg_inst, jtag_inst_width)
+        shift_dr(read, sc_op_width)
+
+        # get data
+        shift_ir(sc_cfg_data, jtag_inst_width)
+        return shift_dr(0, sc_bus_width)
+
+    def load_weight(
+            d_idx, # clog2(ffe_length)
+            w_idx, # 4 bits
+            value, # 10 bits
+    ):
+        print(f'Loading weight d_idx={d_idx}, w_idx={w_idx} with value {value}')
+
+        # determine number of bits for d_idx
+        d_idx_bits = int(ceil(log2(ffe_length)))
+
+        # write wme_ffe_inst
+        wme_ffe_inst = 0
+        wme_ffe_inst |= d_idx & ((1<<d_idx_bits)-1)
+        wme_ffe_inst |= (w_idx & 0b1111) << d_idx_bits
+        write_tc_reg('wme_ffe_inst', wme_ffe_inst)
+
+        # write wme_ffe_data
+        wme_ffe_data = value & 0b1111111111
+        write_tc_reg('wme_ffe_data', wme_ffe_data)
+
+        # pulse wme_ffe_exec
+        write_tc_reg('wme_ffe_exec', 1)
+        write_tc_reg('wme_ffe_exec', 0)
+
+    # Initialize
+    jtag_sleep_us = int(ceil((110/emu_clk_freq)*1e6))
+    set_sleep(jtag_sleep_us)
+    do_init()
+
+    # Clear emulator reset
+    set_emu_rst(0)
+
+    # Reset JTAG
+    print('Reset JTAG')
+    do_reset()
+
+    # Release other reset signals
+    print('Release other reset signals')
+    set_rstb(1)
+
+    # Soft reset
+    print('Soft reset')
+    write_tc_reg('int_rstb', 1)
+    write_tc_reg('en_inbuf', 1)
+    write_tc_reg('en_gf', 1)
+    write_tc_reg('en_v2t', 1)
+
+    # read the ID
+    print('Reading ID...')
+    shift_ir(1, 5)
+    id_result = shift_dr(0, 32)
+    print(f'ID: {id_result}')
+
+    # Set PFD offset
+    print('Set PFD offset')
+    for k in range(16):
+        write_tc_reg(f'ext_pfd_offset[{k}]', 0)
+
+    # Configure PRBS checker
+    print('Configure the PRBS checker')
+    write_tc_reg('sel_prbs_mux', 1) # "0" is ADC, "1" is FFE, "3" is BIST
+
+    # Release the PRBS checker from reset
+    print('Release the PRBS checker from reset')
+    write_tc_reg('prbs_rstb', 1)
+
+    # Set up the FFE
+    dt=1.0/(16.0e9)
+    tau=25.0e-12
+    coeff0 = 128.0/(1.0-exp(-dt/tau))
+    coeff1 = -128.0*exp(-dt/tau)/(1.0-exp(-dt/tau))
+    for loop_var in range(16):
+        for loop_var2 in range(ffe_length):
+            if (loop_var2 == 0):
+                # The argument order for load() is depth, width, value
+                load_weight(loop_var2, loop_var, int(round(coeff0)))
+            elif (loop_var2 == 1):
+                load_weight(loop_var2, loop_var, int(round(coeff1)))
+            else:
+                load_weight(loop_var2, loop_var, 0)
+        write_tc_reg(f'ffe_shift[{loop_var}]', 7)
+
+    # Configure the CDR offsets
+    print('Configure the CDR offsets')
+    write_tc_reg('ext_pi_ctl_offset[0]', 0)
+    write_tc_reg('ext_pi_ctl_offset[1]', 128)
+    write_tc_reg('ext_pi_ctl_offset[2]', 256)
+    write_tc_reg('ext_pi_ctl_offset[3]', 384)
+    write_tc_reg('en_ext_max_sel_mux', 1)
+
+    # Configure the retimer
+    print('Configuring the retimer...')
+    write_tc_reg('retimer_mux_ctrl_1', 0xffff)
+    write_tc_reg('retimer_mux_ctrl_2', 0xffff)
+
+    # Configure the CDR
+    print('Configuring the CDR...')
+    write_tc_reg('Kp', 15)
+    write_tc_reg('Ki', 0)
+    write_tc_reg('invert', 1)
+    write_tc_reg('en_freq_est', 0)
+    write_tc_reg('en_ext_pi_ctl', 0)
+    write_tc_reg('sel_inp_mux', 1) # "0": use ADC output, "1": use FFE output
+
+    # Re-initialize ordering
+    print('Re-initialize ADC ordering')
+    write_tc_reg('en_v2t', 0)
+    write_tc_reg('en_v2t', 1)
+
+    # Wait for CDR to lock
+    print('Wait for PRBS checker to lock')
+    time.sleep(1.0)
+
+    # Run PRBS test.  In order to get a conservative estimate for the throughput, the
+    # test duration includes the time it takes to send JTAG commands to start and stop
+    # the PRBS bit counter.  This is needed because the counter will start running partway
+    # through the first JTAG command, and stop running partway through the second command.
+    # Since we don't know exactly when this happens, a conservative estimate should include
+    # the full time taken by the two JTAG commands.  The effect of their inclusion can be
+    # minimized by running the test for a longer period.
+    print('Run PRBS test')
+    t_start = time.time()
+    write_tc_reg('prbs_checker_mode', 2)
+    time.sleep(prbs_test_dur)
+    write_tc_reg('prbs_checker_mode', 3)
+    t_stop = time.time()
+
+    # Print out duration of PRBS test
+    print(f'PRBS test took {t_stop-t_start} seconds.')
+
+    # Read out PRBS test results
+    print('Read out PRBS test results')
+
+    err_bits = 0
+    err_bits |= read_sc_reg('prbs_err_bits_upper')
+    err_bits <<= 32
+    err_bits |= read_sc_reg('prbs_err_bits_lower')
+    print(f'err_bits: {err_bits}')
+
+    total_bits = 0
+    total_bits |= read_sc_reg('prbs_total_bits_upper')
+    total_bits <<= 32
+    total_bits |= read_sc_reg('prbs_total_bits_lower')
+    print(f'total_bits: {total_bits}')
+
+    # check results
+    print('Checking the results...')
+    assert id_result == 497598771, 'ID mismatch'
+    assert err_bits == 0, 'Bit error detected'
+    assert total_bits > 100000, 'Not enough bits detected'
+
+    # finish test
+    print('OK!')

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -41,6 +41,7 @@ def test_1(board_name, emu_clk_freq, fpga_sim_ctrl):
 
     # Verilog Defines
     src_cfg.add_defines({'VIVADO': None})
+    src_cfg.add_defines({'FPGA_MACRO_MODEL': None})
     src_cfg.add_defines({'GIT_HASH': str(get_git_hash_short())}, fileset='sim')
 
     # Firmware

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -12,9 +12,9 @@ from dragonphy.git_util import get_git_hash_short
 
 THIS_DIR = Path(__file__).resolve().parent
 
-def test_1(board_name, emu_clk_freq):
+def test_1(board_name, emu_clk_freq, fpga_sim_ctrl):
     # Write project config
-    prj = AnasymodProjectConfig()
+    prj = AnasymodProjectConfig(fpga_sim_ctrl)
     prj.set_board_name(board_name)
     prj.set_emu_clk_freq(emu_clk_freq)
     prj.write_to_file(THIS_DIR / 'prj.yaml')

--- a/vlog/fpga_models/analog_core/analog_core.sv
+++ b/vlog/fpga_models/analog_core/analog_core.sv
@@ -1,0 +1,114 @@
+`include "iotype.sv"
+
+module analog_core #(
+    parameter integer Nti=16,
+    parameter integer Npi=9,
+    parameter integer Nadc=8,
+    parameter integer Nout=4
+) (
+    input `pwl_t rx_inp,                                 // RX input (+) (from pad)
+	input `pwl_t rx_inn,                                 // RX input (-) (from pad)
+	input `real_t Vcm,                                   // common mode voltate for termination
+	                                                     // (from pad/inout)
+	
+    input `pwl_t rx_inp_test,                            // RX input (+) for replica ADC (from pad)
+    input `pwl_t rx_inn_test,                            // RX input (-) for replica ADC (from pad)
+    
+	input wire logic ext_clk,                            // (+) 4GHz clock input (from pad)
+	input wire logic mdll_clk,                           // (+) 4GHz clock input (from mdll)
+
+	input wire logic ext_clk_test0,                      // (+) 4GHz clock input (from pad)
+    input wire logic ext_clk_test1,                      // (-) 4GHz clock input (from pad)
+    	
+	input wire logic clk_async,                          // asynchronous clock for phase measurement
+	                                                     // (from DCORE)
+	input wire logic [Npi-1:0] ctl_pi[Nout-1:0],         // PI control code (from DCORE)
+	input wire logic ctl_valid,                          // PI control valid flag (from DCORE) 
+
+	inout `voltage_t Vcal,                               // bias voltage for V2T (from pad)
+	
+	output wire logic clk_adc,                           // clock for retiming adc data assigned from ADC_0
+	                                                     // (to DCORE)
+    output wire logic [Nadc-1:0] adder_out [Nti-1:0],    // adc output (to DCORE)
+    output wire logic [Nti-1:0] sign_out,                // adc output (to DCORE)
+
+    output wire logic [Nadc-1:0] adder_out_rep [1:0],    // adc_rep output (to DCORE)
+    output wire logic [1:0] sign_out_rep                 // adc_rep_output (to DOORE)
+    
+	//acore_debug_intf.acore adbg_intf_i                 // TODO: uncomment
+);
+    (* dont_touch = "true" *) logic emu_clk;
+    (* dont_touch = "true" *) logic emu_rst;
+
+    // instantiate analog slices
+
+    logic [7:0] chunk;
+    logic [1:0] chunk_idx;
+    logic incr_sum;
+    logic last_cycle;
+
+    genvar i;
+    generate
+        for (i=0; i<16; i=i+1) begin
+            // determine the slice offset
+            logic [1:0] slice_offset;
+            assign slice_offset = i%Nout;
+
+            analog_slice analog_slice_i (
+                .chunk(chunk),
+                .chunk_idx(chunk_idx),
+                .pi_ctl(ctl_pi[i/Nout]),
+                .slice_offset(slice_offset),
+                .sample_ctl(last_cycle),
+                .incr_sum(incr_sum),
+                .write_output(last_cycle),
+                .out_sgn(sign_out[i]),
+                .out_mag(adder_out[i]),
+                .clk(emu_clk),
+                .rst(emu_rst)
+            );
+        end
+    endgenerate
+
+    // save history of input bits
+
+    logic [31:0] history;
+
+    always @(posedge emu_clk) begin
+        if (emu_rst) begin
+            history <= 0;
+        end else if (last_cycle) begin
+            history <= {rx_inp, history[31:16]};
+        end else begin
+            history <= history;
+        end
+    end
+
+    // select chunk of input bits
+
+    logic [4:0] history_shift;
+
+    assign history_shift = 5'd8*(5'd3 - chunk_idx);
+    assign chunk = (history >> history_shift) & 8'hFF;
+
+    // main state machine
+
+    logic [3:0] counter;
+
+    always @(posedge emu_clk) begin
+        if (emu_rst) begin
+            counter <= 0;
+        end else if (counter == 5) begin
+            counter <= 0;
+        end else begin
+            counter <= counter + 1;
+        end
+    end
+
+    // assign various control signals
+
+    assign chunk_idx = (counter < 4) ? counter[1:0] : 2'd0;
+    assign incr_sum = (counter != 1) ? 1'b1 : 1'b0;
+    assign last_cycle = (counter == 5) ? 1'b1 : 1'b0;
+
+endmodule

--- a/vlog/fpga_models/analog_core/analog_core.sv
+++ b/vlog/fpga_models/analog_core/analog_core.sv
@@ -136,7 +136,7 @@ module analog_core import const_pack::*; #(
             assign adbg_intf_i.max_sel_mux[i] = '1;
         end
         for (i=0; i<2; i=i+1) begin
-            assign adbg_intf_i.pm_out_rep[0] = 0;
+            assign adbg_intf_i.pm_out_rep[i] = 0;
         end
     endgenerate
 


### PR DESCRIPTION
## Summary

This PR adds a second, higher-level approach for modeling analog effects in DragonPHY.  Rather than modeling the ADC and PI slices in ``analog_core`` directly, ``analog_core`` itself is replaced by a synthesizable behavioral model.  This allows the emulator to do more parallel processing of the analog dynamics, ultimately pushing the emulator throughput from 5 Mb/s to 80 Mb/s (on a ZC706 board).

## Details
* The previous emulation modeling style is still available; ``tests/fpga_system_tests/emu`` uses that approach while ``tests/fpga_system_test/emu_macro`` uses the newer, higher-performance style.  Both are tested to some extent within the DragonPHY regression flow, since there are interesting use cases for both approaches.
* The basic unit of modeling for this new approach is called ``analog_slice``.  It is essentially a macro-model for a PI+ADC, where the PI control code sets the sample time for the ADC, and the ADC slice computes the sampled voltage based on the history of bits transmitted through the link and the analog dynamics of the channel.  Each ``analog_slice`` takes several cycles to compute the sampled voltage, since it operates on the history of previous bits in chunks (8 bits per chunk and 4 chunks total).  This is necessary to fit within the DSP resources available on the FPGA.
* Added new ``pytest`` command-line options ``simulator_name`` and ``fpga_sim_ctrl``
  * For ``simulator_name``, it can be ``iverilog``, ``icarus``, ``xrun``, ``ncsim``, or ``vivado``.  Due to a discrepancy between how ``fault`` and ``anasymod`` refer to simulators, ``{iverilog, ncsim, vivado}`` should be used with ``fault``-based tests, while ``anasymod``-based tests should use ``{icarus, xrun, vivado}``.  This command-line argument replaces the ``SIMULATOR_NAME`` variable that was in many existing tests.  I went through and updated those tests accordingly.
  * For ``fpga_sim_ctrl``, it can be either ``UART_ZYNQ`` (default, recommended) or ``VIVADO_VIO``.  The ``VIVADO_VIO`` option is basically just for comparison purposes because it is so much slower than ``UART_ZYNQ`` (at least 1000x slower).
* Added a new experiment for FPGA emulation called ``experiments/jtag_comparison``.  This experiment looks at 5 different ways to generating a JTAG stimulus for the DUT.
