### PR TITLE
Add noise and jitter to emulation models

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,6 +66,9 @@ steps:
       sed -i 's/\&ffe_length [[:digit:]]\+/\&ffe_length 4/g' config/system.yml
       sed -i 's/\&estimate_depth [[:digit:]]\+/\&estimate_depth 4/g' config/system.yml
 
+      # scale down the channel response length to fit on the regression FPGA
+      sed -i 's/num_terms: [[:digit:]]\+/num_terms: 5/g' config/fpga/chan.yml
+
       # run regression script
       source regress.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ __pycache__
 *.str
 *.diag
 *.svg
+*.pickle
 
 .Xil
 fpga_prj

--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,14 @@ def pytest_addoption(parser):
         '--fpga_sim_ctrl', default='UART_ZYNQ', type=str, help='Emulation control style (UART or VIO)'
     )
 
+    parser.addoption(
+        '--jitter_rms', default=0, type=float, help='RMS sampling jitter (seconds)'
+    )
+
+    parser.addoption(
+        '--noise_rms', default=0, type=float, help='RMS ADC noise (Volts)'
+    )
+
 @pytest.fixture
 def dump_waveforms(request):
     return request.config.getoption('--dump_waveforms')
@@ -64,3 +72,11 @@ def prbs_test_dur(request):
 @pytest.fixture
 def fpga_sim_ctrl(request):
     return request.config.getoption('--fpga_sim_ctrl')
+
+@pytest.fixture
+def jitter_rms(request):
+    return request.config.getoption('--jitter_rms')
+
+@pytest.fixture
+def noise_rms(request):
+    return request.config.getoption('--noise_rms')

--- a/conftest.py
+++ b/conftest.py
@@ -40,6 +40,10 @@ def pytest_addoption(parser):
     parser.addoption(
         '--noise_rms', default=0, type=float, help='RMS ADC noise (Volts)'
     )
+    
+    parser.addoption(
+        '--flatten_hierarchy', default='rebuilt', type=str, help='Vivado synthesis option.'
+    )
 
 @pytest.fixture
 def dump_waveforms(request):
@@ -80,3 +84,7 @@ def jitter_rms(request):
 @pytest.fixture
 def noise_rms(request):
     return request.config.getoption('--noise_rms')
+
+@pytest.fixture
+def flatten_hierarchy(request):
+    return request.config.getoption('--flatten_hierarchy')

--- a/dragonphy/anasymod.py
+++ b/dragonphy/anasymod.py
@@ -15,7 +15,8 @@ class AnasymodProjectConfig:
                 'emu_clk_freq': 5e6,
                 'cpu_debug_mode': 0,
                 'cpu_debug_hierarchies': [],
-                'flatten_hierarchy': 'rebuilt'
+                'flatten_hierarchy': 'rebuilt',
+                'dt_width': 25
             },
             'FPGA_TARGET': {
                 'fpga': {
@@ -30,6 +31,9 @@ class AnasymodProjectConfig:
     def set_flatten_hierarchy(self, value):
         assert value in {'none', 'full', 'rebuilt'}, 'Invalid setting.'
         self.config['PROJECT']['flatten_hierarchy'] = value
+
+    def set_dt_width(self, value):
+        self.config['PROJECT']['dt_width'] = value
 
     def add_debug_probe(self, depth, path):
         self.config['PROJECT']['cpu_debug_hierarchies'].append([depth, path])

--- a/dragonphy/fpga_models/analog_slice.py
+++ b/dragonphy/fpga_models/analog_slice.py
@@ -48,6 +48,10 @@ class AnalogSlice:
         m.add_digital_input('clk')
         m.add_digital_input('rst')
 
+        # Noise controls
+        m.add_analog_input('jitter_rms')
+        m.add_analog_input('noise_rms')
+
         # Sample the pi_ctl code
         m.add_digital_state('pi_ctl_sample', width=system_values['pi_ctl_width'])
         m.set_next_cycle(m.pi_ctl_sample, m.pi_ctl, clk=m.clk, rst=m.rst, ce=m.sample_ctl)
@@ -74,11 +78,15 @@ class AnalogSlice:
                              clk=m.clk, rst=m.rst)
 
         # Compute the evaluation time for this slice
-        t_samp = m.bind_name(
-            't_samp',
+        t_samp_pre = m.bind_name(
+            't_samp_pre',
             ((m.slice_offset*(1<<system_values['pi_ctl_width'])) + m.pi_ctl_sample)
             / ((2.0**system_values['pi_ctl_width'])*system_values['freq_rx'])
         )
+
+        # Add jitter to the sampling time
+        t_samp_jitter = m.set_gaussian_noise('t_samp_jitter', std=m.jitter_rms, clk=m.clk, rst=m.rst)
+        t_samp = m.bind_name('t_samp', t_samp_pre + t_samp_jitter)
 
         # Evaluate the step response function.  Note that the number of evaluation times is the
         # number of chunks plus one.
@@ -116,13 +124,17 @@ class AnalogSlice:
         pulse_resp_sum = m.bind_name('pulse_resp_sum', sum_op(pulse_resp))
 
         # update the overall sample value
-        sample_value = m.add_analog_state('analog_sample', range_=5*system_values['vref_rx'])
+        sample_value_pre = m.add_analog_state('analog_sample_pre', range_=5*system_values['vref_rx'])
         m.set_next_cycle(
-            sample_value,
-            if_(m.incr_sum, sample_value + pulse_resp_sum, pulse_resp_sum),
+            sample_value_pre,
+            if_(m.incr_sum, sample_value_pre + pulse_resp_sum, pulse_resp_sum),
             clk=m.clk,
             rst=m.rst
         )
+
+        # add noise to the sample value
+        sample_noise = m.set_gaussian_noise('sample_noise', std=m.noise_rms, clk=m.clk, rst=m.rst)
+        sample_value = m.bind_name('sample_value', sample_value_pre + sample_noise)
 
         # determine out_sgn (note that the definition is opposite of the typical
         # meaning; "0" means negative)

--- a/dragonphy/fpga_models/analog_slice.py
+++ b/dragonphy/fpga_models/analog_slice.py
@@ -25,6 +25,10 @@ class AnalogSlice:
 
         m = MixedSignalModel(module_name, dt=system_values['dt'], build_dir=build_dir)
 
+        # Random number generator seeds (defaults generated with random.org)
+        m.add_digital_param('jitter_seed', width=32, default=46428)
+        m.add_digital_param('noise_seed', width=32, default=8518)
+
         # Chunk of bits from the history; corresponding delay is bit_idx/freq_tx delay
         m.add_digital_input('chunk', width=system_values['chunk_width'])
         m.add_digital_input('chunk_idx', width=int(ceil(log2(system_values['num_chunks']))))
@@ -85,7 +89,8 @@ class AnalogSlice:
         )
 
         # Add jitter to the sampling time
-        t_samp_jitter = m.set_gaussian_noise('t_samp_jitter', std=m.jitter_rms, clk=m.clk, rst=m.rst)
+        t_samp_jitter = m.set_gaussian_noise('t_samp_jitter', std=m.jitter_rms, clk=m.clk, rst=m.rst,
+                                             lfsr_init=m.jitter_seed)
         t_samp = m.bind_name('t_samp', t_samp_pre + t_samp_jitter)
 
         # Evaluate the step response function.  Note that the number of evaluation times is the
@@ -133,7 +138,8 @@ class AnalogSlice:
         )
 
         # add noise to the sample value
-        sample_noise = m.set_gaussian_noise('sample_noise', std=m.noise_rms, clk=m.clk, rst=m.rst)
+        sample_noise = m.set_gaussian_noise('sample_noise', std=m.noise_rms, clk=m.clk, rst=m.rst,
+                                            lfsr_init=m.noise_seed)
         sample_value = m.bind_name('sample_value', sample_value_pre + sample_noise)
 
         # determine out_sgn (note that the definition is opposite of the typical

--- a/dragonphy/fpga_models/osc_model_core.py
+++ b/dragonphy/fpga_models/osc_model_core.py
@@ -24,7 +24,7 @@ class OscModelCore:
         m.add_analog_input('t_lo')
         m.add_analog_input('t_hi')
         m.add_analog_input('emu_dt')
-        m.add_analog_output('dt_req', init='t_del')
+        m.add_analog_output('dt_req', init=m.t_del)
         m.add_digital_output('clk_val')
 
         # determine if the request was granted

--- a/dragonphy/views.py
+++ b/dragonphy/views.py
@@ -217,7 +217,7 @@ def get_deps_fpga_emu(cell_name=None, impl_file=None, override=None):
             svreal.get_svreal_header().parent,
             msdsl.get_msdsl_header().parent
         ],
-        defines={'DT_WIDTH': 27, 'DT_EXPONENT': -46, 'VIVADO': None},
+        defines={'DT_WIDTH': 25, 'DT_EXPONENT': -46, 'VIVADO': None},
         skip={'svreal', 'assign_real', 'comp_real', 'add_sub_real', 'ite_real',
               'dff_real', 'mul_real', 'mem_digital', 'sync_rom_real', 'DW_tap'},
         no_descend={'chan_core', 'tx_core', 'osc_model_core', 'clk_delay_core',

--- a/experiments/cpu_emu_comparison/experiment.py
+++ b/experiments/cpu_emu_comparison/experiment.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 
+# general imports
+import pickle
 from argparse import ArgumentParser
 from pathlib import Path
+
+# DragonPHY-specific
 from dragonphy import *
 
 THIS_DIR = Path(__file__).parent.resolve()
@@ -13,21 +17,36 @@ parser.add_argument('--dump_waveforms', action='store_true', help='Dump waveform
 parser.add_argument('--jitter_rms', default=0, type=float, help='RMS sampling jitter (seconds)')
 parser.add_argument('--noise_rms', default=0, type=float, help='RMS ADC noise (Volts)')
 parser.add_argument('--nbits', default=600000, type=int, help='Number of bits run through link during testing.')
+parser.add_argument('--cached_deps', action='store_true', help='Read dependencies that were cached in a file (creating the cache file if necessary).')
 args = parser.parse_args()
 
-deps = get_deps_cpu_sim(
-    impl_file=THIS_DIR / 'test.sv',
-    override={
-        'snh': THIS_DIR / 'snh.sv',
-        'V2T_clock_gen_S2D': THIS_DIR / 'V2T_clock_gen_S2D.sv',
-        'stochastic_adc_PR': THIS_DIR / 'stochastic_adc_PR.sv',
-        'phase_interpolator': THIS_DIR / 'phase_interpolator.sv',
-        'input_divider': THIS_DIR / 'input_divider.sv',
-        'output_buffer': THIS_DIR / 'output_buffer.sv',
-        'mdll_r1_top': 'chip_stubs'
-    }
-)
-print(deps)
+# read dependencies from a pickle file if desired
+deps = None
+if args.cached_deps:
+    try:
+        with open('deps.pickle', 'rb') as f:
+            deps = pickle.load(f)
+    except:
+        print('Failed to load dependencies from file.')
+
+# determine the dependencies from scratch if necessary
+if deps is None:
+    deps = get_deps_cpu_sim(
+        impl_file=THIS_DIR / 'test.sv',
+        override={
+            'snh': THIS_DIR / 'snh.sv',
+            'V2T_clock_gen_S2D': THIS_DIR / 'V2T_clock_gen_S2D.sv',
+            'stochastic_adc_PR': THIS_DIR / 'stochastic_adc_PR.sv',
+            'phase_interpolator': THIS_DIR / 'phase_interpolator.sv',
+            'input_divider': THIS_DIR / 'input_divider.sv',
+            'output_buffer': THIS_DIR / 'output_buffer.sv',
+            'mdll_r1_top': 'chip_stubs'
+        }
+    )
+
+# pickle dependencies for future use
+with open('deps.pickle', 'wb') as f:
+    pickle.dump(deps, f)
 
 defines = {
     'JITTER_RMS': args.jitter_rms,

--- a/experiments/cpu_emu_comparison/experiment.py
+++ b/experiments/cpu_emu_comparison/experiment.py
@@ -1,8 +1,16 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
 from pathlib import Path
 from dragonphy import *
 
 THIS_DIR = Path(__file__).parent.resolve()
 BUILD_DIR = THIS_DIR / 'build'
+
+parser = ArgumentParser()
+parser.add_argument('--fast_jtag', action='store_true', help='Use hierarchical I/O rather than true JTAG commands for reading and writing registers.  Useful for test development.')
+parser.add_argument('--dump_waveforms', action='store_true', help='Dump waveforms for debugging purposes.  Useful for debugging, but should be disabled when gathering experimental data.')
+args = parser.parse_args()
 
 deps = get_deps_cpu_sim(
     impl_file=THIS_DIR / 'test.sv',
@@ -18,8 +26,13 @@ deps = get_deps_cpu_sim(
 )
 print(deps)
 
+defines = {}
+if args.fast_jtag:
+    defines['FAST_JTAG'] = True
+
 DragonTester(
     ext_srcs=deps,
     directory=BUILD_DIR,
-    dump_waveforms=False
+    defines=defines,
+    dump_waveforms=args.dump_waveforms
 ).run()

--- a/experiments/cpu_emu_comparison/experiment.py
+++ b/experiments/cpu_emu_comparison/experiment.py
@@ -10,6 +10,9 @@ BUILD_DIR = THIS_DIR / 'build'
 parser = ArgumentParser()
 parser.add_argument('--fast_jtag', action='store_true', help='Use hierarchical I/O rather than true JTAG commands for reading and writing registers.  Useful for test development.')
 parser.add_argument('--dump_waveforms', action='store_true', help='Dump waveforms for debugging purposes.  Useful for debugging, but should be disabled when gathering experimental data.')
+parser.add_argument('--jitter_rms', default=0, type=float, help='RMS sampling jitter (seconds)')
+parser.add_argument('--noise_rms', default=0, type=float, help='RMS ADC noise (Volts)')
+parser.add_argument('--nbits', default=600000, type=int, help='Number of bits run through link during testing.')
 args = parser.parse_args()
 
 deps = get_deps_cpu_sim(
@@ -26,7 +29,11 @@ deps = get_deps_cpu_sim(
 )
 print(deps)
 
-defines = {}
+defines = {
+    'JITTER_RMS': args.jitter_rms,
+    'NOISE_RMS': args.noise_rms,
+    'NBITS': args.nbits
+}
 if args.fast_jtag:
     defines['FAST_JTAG'] = True
 

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -139,3 +139,25 @@ Jul 17, 2020
   * Interesting to observe that slightly higher noise is tolerated in this setup, particularly for jitter.  Possibly due to the Gaussian tail distortion in the emulator, or differences in the channel model (PWL LPF in simulation vs. PWL lookup table superposition).
   * r7cad-generic processor, CentOS Linux release 7.7.1908 (Core), 128 GB RAM
     * /proc/cpuinfo did not display the real CPU information since r7cad-generic is a VM
+
+July 18, 2020
+* Gaussian noise expermient with "low-level" model.  Emulation on ZC706, with flatten_hierarchy set to none for debugging.
+  * Command: ``time pytest tests/fpga_system_tests/emu/test_emu.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 20e6 --prbs_test_dur 1 --flatten_hierarchy none``
+  * PRBS test took  seconds.
+  * Total bits: 
+  *  Mb/s
+  * Slice LUTs: 64852 / 218600
+    * analog_core: 8336
+    * digital_core: 47254
+  * Slice Registers: 26603 / 437200
+    * analog_core: 2039
+    * digital_core: 17635
+  * Slice: 20911 / 54650
+    * analog_core: 2694 
+    * digital_core: 15253
+  * DSP: 581 / 900
+  * BRAM: 53.5 / 545
+  * Build time: 33m36.902s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * Max noise code: "560" (--noise_rms 56e-3)
+  * Max jitter code: "26" (--jitter_rms 2.6e-12)

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -85,3 +85,23 @@ July 8, 2020
   * Build time: 37m31.047s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
 
+July 16, 2020
+* First experiment with Gaussian noise -- there is an issue in this particular implementation having to do with LFSR seeding, since all of the analog_slices unfortunately are using the same seeds (although within each slice, the seeds for the sampling time and ADC noise are different).  Emulation with 16x channels on ZC706, using a macro model for analog_core that computes all of the ADC samples in parallel.  This measurement used a history length of 32 bits, processed over 4 cycles in chunks of size 8.  For this experiment, "flatten_hierarchy" was set to "rebuilt" (default from Vivado).
+  * Command: ``time pytest tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 30e6 --prbs_test_dur 1``
+  * PRBS test took 30.050543308258057 seconds.
+  * Total bits: 2402858272
+  * 79.96 Mb/s
+  * Slice LUTs: 94128 / 218600
+    * analog_core: 38263
+    * digital_core: 40007
+  * Slice Registers: 26261 / 437200
+    * analog_core: 4063
+    * digital_core: 17795
+  * Slice: 29521 / 54650
+    * analog_core: 12110
+    * digital_core: 14743
+  * DSP: 850 / 900
+  * BRAM: 50.5 / 545
+  * Build time: 40m5.904s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * In CPU simulation, the max jitter is "31" (3.1ps) and max noise is "658" (65.8mV); the observation period is approximately 10,000 bits.  In emulation, which is running about 2 billion bits over 30 seconds, the max jitter is reduced to "23" (2.3ps) and max noise is reduced to "564" (56.4mV).  The "maximum" in this case is the highest value of the parameter that yields no bit errors over the observation period, with the other noise sources set to "0".

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -127,3 +127,12 @@ July 16, 2020
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
   * Max noise code: "501" (--noise_rms 50.1e-3)
   * Max jitter code: "25" (--jitter_rms 2.5e-12)
+
+Jul 17, 2020
+* Simulation with 16x channels (using Xcelium)
+  * Command: ./experiment.py --noise_rms 10e-3 --jitter_rms 1e-12
+  * PRBS test took 38.306903 seconds.
+  * Total_bits: 608192
+  * Throughput: 15.9 kb/s
+  * r7cad-generic processor, CentOS Linux release 7.7.1908 (Core), 128 GB RAM
+    * /proc/cpuinfo did not display the real CPU information since r7cad-generic is a VM

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -180,3 +180,30 @@ July 18, 2020
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
   * Max noise code: "570" (--noise_rms 57e-3)
   * Max jitter code: "26" (--jitter_rms 2.6e-12)
+
+July 19, 2020
+* Gaussian noise expermient with "low-level" model.  Emulation on ZC706 with flatten_hierarchy set to default (rebuilt).  For this experiment, there is just one CPU register each for noise_rms and jitter_rms to reduce resource utilization and simplify the design.
+  * command: ``time pytest tests/fpga_system_tests/emu/test_emu.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 20e6 --prbs_test_dur 1``
+  * PRBS test took 30.042307376861572 seconds.
+  * Total bits: 150163760
+  * 4.998 Mb/s
+  * Slice LUTs: 77359 / 218600
+    * analog_core: 15556
+    * digital_core: 40056
+  * Slice Registers: 24928 / 437200
+    * analog_core: 1247
+    * digital_core: 17813
+  * Slice: 24221 / 54650
+    * analog_core: 4635
+    * digital_core: 14152
+  * DSP: 238 / 900
+    * interesting to note that some multiplications use up to 4 DSPs while others use 100-200 LUTs
+    * for rx_adc_core, LUT utilization is 698 and DSP utilization is 6 (16x instances)
+    * for clk_delay_core, LUT utilization is 701 and DSP utilization is 7 (4x instances)
+    * for chan_core, LUT utilization is 11,856 and DSP utilization is 100 (1x instances)
+    * total LUT utilization ends up being 13,972 for ADC and PI (124 DSPs)
+  * BRAM: 49 / 545
+  * Build time: 34m28.312s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * Max noise code: "560" (--noise_rms 56e-3)
+  * Max jitter code: "26" (--jitter_rms 2.6e-12)

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -134,5 +134,8 @@ Jul 17, 2020
   * PRBS test took 38.306903 seconds.
   * Total_bits: 608192
   * Throughput: 15.9 kb/s
+  * Max noise: 61 mV RMS  (@600k bits)
+  * Max jitter: 4.3 ps RMS (@600k bits)
+  * Interesting to observe that slightly higher noise is tolerated in this setup, particularly for jitter.  Possibly due to the Gaussian tail distortion in the emulator, or differences in the channel model (PWL LPF in simulation vs. PWL lookup table superposition).
   * r7cad-generic processor, CentOS Linux release 7.7.1908 (Core), 128 GB RAM
     * /proc/cpuinfo did not display the real CPU information since r7cad-generic is a VM

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -161,3 +161,22 @@ July 18, 2020
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
   * Max noise code: "560" (--noise_rms 56e-3)
   * Max jitter code: "26" (--jitter_rms 2.6e-12)
+* same as previous, but using default flatten_hierarchy setting (rebuilt)
+  * PRBS test took 30.04912281036377 seconds.
+  * Total bits: 150773520
+  * 5.018 Mb/s
+  * Slice LUTs: 76989 / 218600
+    * analog_core: 15547
+    * digital_core: 40043
+  * Slice Registers: / 437200
+    * analog_core: 1247
+    * digital_core: 17813
+  * Slice: 23970 / 54650
+    * analog_core: 4656
+    * digital_core: 14123
+  * DSP: 258 / 900
+  * BRAM: 49 / 545
+  * Build time: 34m7.993s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * Max noise code: "570" (--noise_rms 57e-3)
+  * Max jitter code: "26" (--jitter_rms 2.6e-12)

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -105,3 +105,25 @@ July 16, 2020
   * Build time: 40m5.904s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
   * In CPU simulation, the max jitter is "31" (3.1ps) and max noise is "658" (65.8mV); the observation period is approximately 10,000 bits.  In emulation, which is running about 2 billion bits over 30 seconds, the max jitter is reduced to "23" (2.3ps) and max noise is reduced to "564" (56.4mV).  The "maximum" in this case is the highest value of the parameter that yields no bit errors over the observation period, with the other noise sources set to "0".
+
+July 16, 2020
+* Second experiment with Gaussian noise -- this one fixed the previous issue with random seeding.  Emulation with 16x channels on ZC706, using a macro model for analog_core that computes all of the ADC samples in parallel.  This measurement used a history length of 32 bits, processed over 4 cycles in chunks of size 8.  For this experiment, "flatten_hierarchy" was set to "rebuilt" (default from Vivado).
+  * Command: ``time pytest tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 30e6 --prbs_test_dur 1``
+  * PRBS test took 30.038529634475708 seconds.
+  * Total bits: 2402005872
+  * 79.96 Mb/s
+  * Slice LUTs: 94244 / 218600
+    * analog_core: 38184
+    * digital_core: 40123
+  * Slice Registers: 26259 / 437200
+    * analog_core: 4060
+    * digital_core: 17796
+  * Slice: 29215 / 54650
+    * analog_core: 12050
+    * digital_core: 14464
+  * DSP: 850 / 900
+  * BRAM: 50.5 / 545
+  * Build time: 42m31.562s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * Max noise code: "501" (--noise_rms 50.1e-3)
+  * Max jitter code: "25" (--jitter_rms 2.5e-12)

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -207,3 +207,27 @@ July 19, 2020
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
   * Max noise code: "560" (--noise_rms 56e-3)
   * Max jitter code: "26" (--jitter_rms 2.6e-12)
+* same as above, but with LONG_WIDTH_REAL and DT_WIDTH reduced from 32 to 25
+  * command: ``time pytest tests/fpga_system_tests/emu/test_emu.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 20e6 --prbs_test_dur 1``
+  * PRBS test took 30.054484367370605 seconds.
+  * Total bits: 150206112
+  * 4.998 Mb/s
+  * Slice LUTs: 62288 / 218600
+    * analog_core: 6407
+    * digital_core: 40117
+  * Slice Registers: 24690 / 437200
+    * analog_core: 1191
+    * digital_core: 17813
+  * Slice: 20121 / 54650
+    * analog_core: 2040
+    * digital_core: 14248
+  * DSP: 187 / 900
+    * for rx_adc_core, LUT utilization is 255 and DSP utilization is 5 (16x instances)
+    * for clk_delay_core, LUT utilization is 410 and DSP utilization is 5 (4x instances)
+    * for chan_core, LUT utilization is 6096 and DSP utilization is 75 (1x instances)
+    * total LUT utilization ends up being 5720 for ADC and PI (100 DSPs)
+  * BRAM: 48.5 / 545
+  * Build time: 30m44.765s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * Max noise code: "560" (--noise_rms 56e-3)
+  * Max jitter code: "26" (--jitter_rms 2.6e-12)

--- a/experiments/cpu_emu_comparison/simvision.svcf
+++ b/experiments/cpu_emu_comparison/simvision.svcf
@@ -1,0 +1,97 @@
+# SimVision Command Script (Fri Jul 17 11:29:14 AM PDT 2020)
+#
+# Version 19.03.s003
+#
+# You can restore this configuration with:
+#
+#     simvision -input /home/sherbst/Code/dragonphy2/experiments/cpu_emu_comparison/simvision.svcf
+#  or simvision -input /home/sherbst/Code/dragonphy2/experiments/cpu_emu_comparison/simvision.svcf database1 database2 ...
+#
+
+
+#
+# Preferences
+#
+preferences set plugin-enable-svdatabrowser-new 1
+preferences set toolbar-Standard-Console {
+  usual
+  position -pos 1
+}
+preferences set toolbar-Search-Console {
+  usual
+  position -pos 2
+}
+preferences set toolbar-Standard-WaveWindow {
+  usual
+  position -pos 1
+}
+preferences set plugin-enable-groupscope 0
+preferences set plugin-enable-interleaveandcompare 0
+preferences set plugin-enable-waveformfrequencyplot 0
+preferences set whats-new-dont-show-at-startup 1
+
+#
+# Databases
+#
+array set dbNames ""
+set dbNames(realName1) [ database require waves -hints {
+	file ./experiments/cpu_emu_comparison/build/waves.shm/waves.trn
+	file /home/sherbst/Code/dragonphy2/experiments/cpu_emu_comparison/build/waves.shm/waves.trn
+}]
+if {$dbNames(realName1) == ""} {
+    set dbNames(realName1) waves
+}
+
+#
+# Mnemonic Maps
+#
+mmap new  -reuse -name {Boolean as Logic} -radix %b -contents {{%c=FALSE -edgepriority 1 -shape low}
+{%c=TRUE -edgepriority 1 -shape high}}
+mmap new  -reuse -name {Example Map} -radix %x -contents {{%b=11???? -bgcolor orange -label REG:%x -linecolor yellow -shape bus}
+{%x=1F -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=2C -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=* -label %x -linecolor gray -shape bus}}
+
+#
+# Waveform windows
+#
+if {[catch {window new WaveWindow -name "Waveform 1" -geometry 1311x563+48+62}] != ""} {
+    window geometry "Waveform 1" 1311x563+48+62
+}
+window target "Waveform 1" on
+waveform using {Waveform 1}
+waveform sidebar select designbrowser
+waveform set \
+    -primarycursor TimeA \
+    -signalnames name \
+    -signalwidth 175 \
+    -units ns \
+    -valuewidth 75
+waveform baseline set -time 18,960,190,546,529fs
+
+set id [waveform add -signals [subst  {
+	{$dbNames(realName1)::[format {test.top_i.iacore.ctl_pi[0]}]}
+	} ]]
+waveform format $id -radix %d -trace analogSampleAndHold
+waveform axis range $id -for default -min 0 -max 72 -scale linear
+set id [waveform add -signals [subst  {
+	{$dbNames(realName1)::[format {test.top_i.idcore.adcout_unfolded[0]}]}
+	} ]]
+waveform format $id -trace analogSampleAndHold
+waveform axis range $id -for default -min -127 -max 127 -scale linear
+set id [waveform add -signals [subst  {
+	{$dbNames(realName1)::[format {test.top_i.idcore.estimated_bits[0]}]}
+	} ]]
+waveform format $id -radix %d -trace analogSampleAndHold
+waveform axis range $id -for default -min -311 -max 439 -scale linear
+
+waveform xview limits 1592.298438ns 1904.923438ns
+
+#
+# Waveform Window Links
+#
+
+#
+# Layout selection
+#
+

--- a/experiments/cpu_emu_comparison/stochastic_adc_PR.sv
+++ b/experiments/cpu_emu_comparison/stochastic_adc_PR.sv
@@ -5,6 +5,10 @@
 `include "mLingua_pwl.vh"
 `include "iotype.sv"
 
+`ifndef NOISE_RMS
+    `define NOISE_RMS 0.0
+`endif
+
 module stochastic_adc_PR #(
     parameter Nctl_v2t = 5,
     parameter Nctl_TDC = 5,
@@ -47,6 +51,15 @@ module stochastic_adc_PR #(
 
     PWLMethod pm=new;
     `get_timeunit
+
+    ////////////////////////////////
+    // random seed initialization //
+    ////////////////////////////////
+
+    integer seed;
+    initial begin
+        seed = $urandom();
+    end
 
     //////////////////////////////
     // synchronization function //
@@ -118,6 +131,9 @@ module stochastic_adc_PR #(
             out_sgn = 0;
             samp = samp_n - samp_p;
         end
+
+        // add noise
+        samp += (`NOISE_RMS)*($dist_normal(seed, 0, 1000)/1000.0);
 
         // determine output magnitude
         out_mag = ((1.0*samp) / (0.3)) * ((2.0**(Nadc-1.0))-1.0);

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 requires_list = [
     # anasymod ecosystem
     'svreal==0.2.2',
-    'msdsl==0.2.6',
+    'msdsl==0.2.7',
     'anasymod==0.3.2',
     # system-verilog parser
     'svinst==0.1.5',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 requires_list = [
     # anasymod ecosystem
     'svreal==0.2.2',
-    'msdsl==0.2.7',
+    'msdsl==0.2.9',
     'anasymod==0.3.2',
     # system-verilog parser
     'svinst==0.1.5',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as fh:
 requires_list = [
     # anasymod ecosystem
     'svreal==0.2.2',
-    'msdsl==0.2.9',
+    'msdsl==0.3.0',
     'anasymod==0.3.2',
     # system-verilog parser
     'svinst==0.1.5',

--- a/tests/fpga_block_tests/adc_model/test_adc_model.py
+++ b/tests/fpga_block_tests/adc_model/test_adc_model.py
@@ -32,7 +32,7 @@ def model(in_, n, vref):
     # return result
     return sgn, mag
 
-def test_chan_model(simulator_name, n=8, vref=0.4, should_print=False):
+def test_adc_model(simulator_name, n=8, vref=0.4, should_print=False):
     # set defaults
     if simulator_name is None:
         simulator_name = 'vivado'
@@ -45,6 +45,7 @@ def test_chan_model(simulator_name, n=8, vref=0.4, should_print=False):
             clk_val=m.BitIn,
             out_mag=m.Out(m.Bits[n]),
             out_sgn=m.BitOut,
+            noise_rms=fault.RealIn,
             emu_rst=m.BitIn,
             emu_clk=m.ClockIn
         )
@@ -53,10 +54,8 @@ def test_chan_model(simulator_name, n=8, vref=0.4, should_print=False):
     t = fault.Tester(dut, dut.emu_clk)
 
     # initialize
-    t.poke(dut.in_, 0.0)
-    t.poke(dut.clk_val, 0)
+    t.zero_inputs()
     t.poke(dut.emu_rst, 1)
-    t.poke(dut.emu_clk, 0)
     t.step(4)
 
     # clear reset

--- a/tests/fpga_block_tests/adc_model/test_adc_model.sv
+++ b/tests/fpga_block_tests/adc_model/test_adc_model.sv
@@ -4,25 +4,35 @@ module test_adc_model #(
     parameter integer n=8
 ) (
     input real in_,
+    input real noise_rms,
     input wire logic clk_val,
     output wire logic [(n-1):0] out_mag,
     output wire logic out_sgn,
     input wire logic emu_rst,
     input wire logic emu_clk
 );
-    // Convert real to fixed-point
+    // Convert in_ to fixed-point
     `MAKE_REAL(in_int, 10);
     assign `FORCE_REAL(in_, in_int);
 
+    // Convert noise_rms to fixed-point
+    `MAKE_REAL(noise_rms_int, 10e-3);
+    assign `FORCE_REAL(noise_rms, noise_rms_int);
+
     // Instantiate model
     rx_adc_core #(
-        `PASS_REAL(in_, in_int)
+        `PASS_REAL(in_, in_int),
+        `PASS_REAL(noise_rms, noise_rms_int)
     ) rx_adc_core_i (
         // main I/O: input, output, and clock
         .in_(in_int),
         .out_mag(out_mag),
         .out_sgn(out_sgn),
         .clk_val(clk_val),
+
+        // noise control
+        .noise_rms(noise_rms_int),
+
         // emulator I/O
         .emu_clk(emu_clk),
         .emu_rst(emu_rst)

--- a/tests/fpga_block_tests/analog_core/test_analog_core.py
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.py
@@ -91,6 +91,8 @@ def test_analog_core(simulator_name, dump_waveforms, num_tests=100):
     io_dict['sign_out'] = m.Out(m.Bits[16])
     io_dict['clk'] = m.BitIn
     io_dict['rst'] = m.BitIn
+    io_dict['jitter_rms_int'] = m.In(m.Bits[7])
+    io_dict['noise_rms_int'] = m.In(m.Bits[11])
 
     # declare circuit
     class dut(m.Circuit):

--- a/tests/fpga_block_tests/analog_core/test_analog_core.sv
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.sv
@@ -32,7 +32,11 @@ module test_analog_core import const_pack::*; #(
 
     // Emulator clock and reset
     input clk,
-    input rst
+    input rst,
+
+    // Jitter/Noise commands
+    input [6:0] jitter_rms_int,
+    input [10:0] noise_rms_int
 );
     // wire ctl_pi
     logic [Npi-1:0] ctl_pi [Nout-1:0];
@@ -92,6 +96,8 @@ module test_analog_core import const_pack::*; #(
     // wire emulator control signals through the hierarchy
     assign analog_core_i.emu_clk = clk;
     assign analog_core_i.emu_rst = rst;
+    assign analog_core_i.jitter_rms_int = jitter_rms_int;
+    assign analog_core_i.noise_rms_int = noise_rms_int;
 
     // waveform dumping
     initial begin

--- a/tests/fpga_block_tests/analog_slice/test_analog_slice.py
+++ b/tests/fpga_block_tests/analog_slice/test_analog_slice.py
@@ -16,7 +16,8 @@ from msdsl import get_msdsl_header
 # DragonPHY imports
 from dragonphy import get_file, Filter
 
-BUILD_DIR = Path(__file__).resolve().parent / 'build'
+THIS_DIR = Path(__file__).resolve().parent
+BUILD_DIR = THIS_DIR / 'build'
 
 DELTA = 100e-9
 TPER = 1e-6
@@ -84,7 +85,7 @@ def test_analog_slice(simulator_name, slice_offset, dump_waveforms, num_tests=10
 
     # declare circuit
     class dut(m.Circuit):
-        name = 'analog_slice'
+        name = 'test_analog_slice'
         io = m.IO(
             chunk=m.In(m.Bits[CFG['chunk_width']]),
             chunk_idx=m.In(m.Bits[int(ceil(log2(CFG['num_chunks'])))]),
@@ -96,7 +97,9 @@ def test_analog_slice(simulator_name, slice_offset, dump_waveforms, num_tests=10
             out_sgn=m.BitOut,
             out_mag=m.Out(m.Bits[CFG['n_adc']]),
             clk=m.BitIn,
-            rst=m.BitIn
+            rst=m.BitIn,
+            jitter_rms=fault.RealIn,
+            noise_rms=fault.RealIn
         )
 
     # create the tester
@@ -177,7 +180,10 @@ def test_analog_slice(simulator_name, slice_offset, dump_waveforms, num_tests=10
         target='system-verilog',
         directory=BUILD_DIR,
         simulator=simulator_name,
-        ext_srcs=[get_file('build/fpga_models/analog_slice/analog_slice.sv')],
+        ext_srcs=[
+            get_file('build/fpga_models/analog_slice/analog_slice.sv'),
+            THIS_DIR / 'test_analog_slice.sv'
+        ],
         inc_dirs=[
             get_svreal_header().parent,
             get_msdsl_header().parent

--- a/tests/fpga_block_tests/analog_slice/test_analog_slice.sv
+++ b/tests/fpga_block_tests/analog_slice/test_analog_slice.sv
@@ -1,0 +1,51 @@
+`include "svreal.sv"
+
+module test_analog_slice #(
+    parameter integer chunk_width=8,
+    parameter integer num_chunks=4,
+    parameter integer pi_ctl_width=9,
+    parameter integer slices_per_bank=4,
+    parameter integer n_adc=8
+) (
+    input wire logic [(chunk_width-1):0] chunk,
+    input wire logic [($clog2(num_chunks)-1):0] chunk_idx,
+    input wire logic [(pi_ctl_width-1):0] pi_ctl,
+    input wire logic [($clog2(slices_per_bank)-1):0] slice_offset,
+    input wire logic sample_ctl,
+    input wire logic incr_sum,
+    input wire logic write_output,
+    output wire logic out_sgn,
+    output wire logic [(n_adc-1):0] out_mag,
+    input wire logic clk,
+    input wire logic rst,
+    input real jitter_rms,
+    input real noise_rms
+);
+    // declare svreal types for jitter and noise
+    `MAKE_REAL(jitter_rms_int, 10e-12);
+    `MAKE_REAL(noise_rms_int, 10e-3);
+
+    // assign real-number types to svreal types
+    assign `FORCE_REAL(jitter_rms, jitter_rms_int);
+    assign `FORCE_REAL(noise_rms, noise_rms_int);
+
+    // instantiate the slice
+    analog_slice #(
+        `PASS_REAL(jitter_rms, jitter_rms_int),
+        `PASS_REAL(noise_rms, noise_rms_int)
+    ) analog_slice_i (
+        .chunk(chunk),
+        .chunk_idx(chunk_idx),
+        .pi_ctl(pi_ctl),
+        .slice_offset(slice_offset),
+        .sample_ctl(sample_ctl),
+        .incr_sum(incr_sum),
+        .write_output(write_output),
+        .out_sgn(out_sgn),
+        .out_mag(out_mag),
+        .clk(clk),
+        .rst(rst),
+        .jitter_rms(jitter_rms_int),
+        .noise_rms(noise_rms_int)
+    );
+endmodule

--- a/tests/fpga_block_tests/clk_delay/test_clk_delay.py
+++ b/tests/fpga_block_tests/clk_delay/test_clk_delay.py
@@ -41,6 +41,7 @@ def test_clk_delay(simulator_name, float_real):
             clk_o_val=m.BitOut,
             dt_req=fault.RealIn,
             emu_dt=fault.RealOut,
+            jitter_rms=fault.RealIn,
             emu_clk=m.In(m.Clock),
             emu_rst=m.BitIn
         )
@@ -62,10 +63,8 @@ def test_clk_delay(simulator_name, float_real):
     del_nom = (DEL_CODE / (2.0**N_BITS)) * T_PER
 
     # initialize
+    t.zero_inputs()
     t.poke(dut.code, DEL_CODE)
-    t.poke(dut.clk_i_val, 0)
-    t.poke(dut.dt_req, 0.0)
-    t.poke(dut.emu_clk, 0)
     t.poke(dut.emu_rst, 1)
 
     # apply reset

--- a/tests/fpga_block_tests/clk_delay/test_clk_delay.py
+++ b/tests/fpga_block_tests/clk_delay/test_clk_delay.py
@@ -122,7 +122,7 @@ def test_clk_delay(simulator_name, float_real):
 
     # run the simulation
     defines = {
-        'DT_WIDTH': 27,
+        'DT_WIDTH': 25,
         'DT_EXPONENT': -46
     }
     if float_real:

--- a/tests/fpga_block_tests/clk_delay/test_clk_delay.sv
+++ b/tests/fpga_block_tests/clk_delay/test_clk_delay.sv
@@ -6,9 +6,14 @@ module test_clk_delay (
     output wire logic clk_o_val,
     input real dt_req,
     output real emu_dt,
+    input real jitter_rms,
     input wire logic emu_clk,
     input wire logic emu_rst
 );
+    // jitter control
+    `MAKE_REAL(jitter_rms_int, 10e-12);
+    assign `FORCE_REAL(jitter_rms, jitter_rms_int);
+
     // format for timesteps
     `REAL_FROM_WIDTH_EXP(emu_dt_int, `DT_WIDTH, `DT_EXPONENT);
     `REAL_FROM_WIDTH_EXP(dt_req_ext, `DT_WIDTH, `DT_EXPONENT);
@@ -33,18 +38,25 @@ module test_clk_delay (
     clk_delay_core #(
         `PASS_REAL(emu_dt, emu_dt_int),
         `PASS_REAL(dt_req, dt_req_dly),
-        `PASS_REAL(dt_req_max, dt_req_max)
+        `PASS_REAL(dt_req_max, dt_req_max),
+        `PASS_REAL(jitter_rms, jitter_rms_int)
     ) clk_delay_core_i (
         // main I/O: delay code, clock in/out values
         .code(code),
         .clk_i_val(clk_i_val),
         .clk_o_val(clk_o_val),
+
         // timestep control: DT request and response
         .dt_req(dt_req_dly),
         .emu_dt(emu_dt_int),
+
+        // jitter control
+        .jitter_rms(jitter_rms_int),
+
         // emulator clock and reset
         .emu_clk(emu_clk),
         .emu_rst(emu_rst),
+
         // additional input: maximum timestep
         .dt_req_max(dt_req_max)
     );

--- a/tests/fpga_block_tests/osc_model/test_osc_model.py
+++ b/tests/fpga_block_tests/osc_model/test_osc_model.py
@@ -108,7 +108,7 @@ def test_osc_model(simulator_name, float_real):
 
     # run the simulation
     defines = {
-        'DT_WIDTH': 27,
+        'DT_WIDTH': 25,
         'DT_EXPONENT': -46
     }
     if float_real:

--- a/tests/fpga_system_tests/emu/main.c
+++ b/tests/fpga_system_tests/emu/main.c
@@ -21,6 +21,10 @@ void do_init() {
    set_emu_ctrl_data(0);
    set_emu_dec_thr(0);
 
+   // noise controls
+   set_jitter_rms_int(0);
+   set_noise_rms_int(0);
+
    // JTAG-specific
    set_tdi(0);
    set_tck(0);

--- a/tests/fpga_system_tests/emu/main.c
+++ b/tests/fpga_system_tests/emu/main.c
@@ -14,6 +14,32 @@ void cycle() {
     usleep(sleep_time);
 }
 
+void set_jitter_rms(u32 value) {
+   set_jitter_rms_0(value);
+   set_jitter_rms_1(value);
+   set_jitter_rms_2(value);
+   set_jitter_rms_3(value);
+}
+
+void set_noise_rms(u32 value) {
+   set_noise_rms_0(value);
+   set_noise_rms_1(value);
+   set_noise_rms_2(value);
+   set_noise_rms_3(value);
+   set_noise_rms_4(value);
+   set_noise_rms_5(value);
+   set_noise_rms_6(value);
+   set_noise_rms_7(value);
+   set_noise_rms_8(value);
+   set_noise_rms_9(value);
+   set_noise_rms_10(value);
+   set_noise_rms_11(value);
+   set_noise_rms_12(value);
+   set_noise_rms_13(value);
+   set_noise_rms_14(value);
+   set_noise_rms_15(value);
+}
+
 void do_init() {
    // emulator controls
    set_emu_rst(1);
@@ -22,8 +48,8 @@ void do_init() {
    set_emu_dec_thr(0);
 
    // noise controls
-   set_jitter_rms_int(0);
-   set_noise_rms_int(0);
+   set_jitter_rms(0);
+   set_noise_rms(0);
 
    // JTAG-specific
    set_tdi(0);
@@ -143,6 +169,21 @@ u32 read_id() {
     return shift_dr(0, 32);
 }
 
+enum cmd_t {
+    RESET,
+    INIT,
+    EXIT,
+    ID,
+    SIR,
+    SDR,
+    QSDR, // "quiet" SDR -- does not print anything
+    SET_RSTB,
+    SET_EMU_RST,
+    SET_SLEEP,
+    SET_NOISE_RMS,
+    SET_JITTER_RMS
+} cmd;
+
 int main() {
     // character buffering
     u32 idx = 0;
@@ -150,7 +191,6 @@ int main() {
     char buf [32];
     
     // command processing;
-    u32 cmd;
     u32 arg1;
     u32 arg2;
     u32 nargs = 0;
@@ -171,53 +211,75 @@ int main() {
                 buf[idx++] = '\0';
                 if (nargs == 0) {
                     if (strcmp(buf, "RESET") == 0) {
+                        cmd = RESET;
                         do_reset();
                         nargs = 0;
                     } else if (strcmp(buf, "INIT") == 0) {
+                        cmd = INIT;
                         do_init();
                         nargs = 0;
                     } else if (strcmp(buf, "EXIT") == 0) {
+                        cmd = EXIT;
                         return 0;
                     } else if (strcmp(buf, "ID") == 0) {
+                        cmd = ID;
                         xil_printf("%lu\r\n", read_id());
+                        nargs = 0;
                     } else if (strcmp(buf, "SIR") == 0) {
-                        cmd = 1;
+                        cmd = SIR;
                         nargs++;
                     } else if (strcmp(buf, "SDR") == 0) {
-                        cmd = 2;
+                        cmd = SDR;
+                        nargs++;
+                    } else if (strcmp(buf, "QSDR") == 0) {
+                        cmd = QSDR;
                         nargs++;
                     } else if (strcmp(buf, "SET_RSTB") == 0) {
-                        cmd = 3;
+                        cmd = SET_RSTB;
                         nargs++;
                     } else if (strcmp(buf, "SET_EMU_RST") == 0) {
-                        cmd = 4;
+                        cmd = SET_EMU_RST;
                         nargs++;
                     } else if (strcmp(buf, "SET_SLEEP") == 0) {
-                        cmd = 5;
+                        cmd = SET_SLEEP;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_NOISE_RMS") == 0) {
+                        cmd = SET_NOISE_RMS;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_JITTER_RMS") == 0) {
+                        cmd = SET_JITTER_RMS;
                         nargs++;
                     } else {
 	                xil_printf("ERROR: Unknown command\r\n");
 		            }
                 } else if (nargs == 1) {
                     sscanf(buf, "%lu", &arg1);
-                    if (cmd == 3) {
+                    if (cmd == SET_RSTB) {
                         set_rstb(arg1);
                         nargs=0;
-                    } else if (cmd == 4) {
+                    } else if (cmd == SET_EMU_RST) {
                         set_emu_rst(arg1);
                         nargs=0;
-                    } else if (cmd == 5) {
+                    } else if (cmd == SET_SLEEP) {
                         sleep_time = arg1;
+                        nargs=0;
+                    } else if (cmd == SET_NOISE_RMS) {
+                        set_noise_rms(arg1);
+                        nargs=0;
+                    } else if (cmd == SET_JITTER_RMS) {
+                        set_jitter_rms(arg1);
                         nargs=0;
                     } else {
                         nargs++;
                     }
                 } else if (nargs == 2) {
                     sscanf(buf, "%lu", &arg2);
-                    if (cmd == 1) {
+                    if (cmd == SIR) {
                         shift_ir(arg1, arg2);
-                    } else if (cmd == 2) {
+                    } else if (cmd == SDR) {
                         xil_printf("%lu\r\n", shift_dr(arg1, arg2));
+                    } else if (cmd == QSDR) {
+                        shift_dr(arg1, arg2);
                     }
                     nargs = 0;
                 }  

--- a/tests/fpga_system_tests/emu/main.c
+++ b/tests/fpga_system_tests/emu/main.c
@@ -14,32 +14,6 @@ void cycle() {
     usleep(sleep_time);
 }
 
-void set_jitter_rms(u32 value) {
-   set_jitter_rms_0(value);
-   set_jitter_rms_1(value);
-   set_jitter_rms_2(value);
-   set_jitter_rms_3(value);
-}
-
-void set_noise_rms(u32 value) {
-   set_noise_rms_0(value);
-   set_noise_rms_1(value);
-   set_noise_rms_2(value);
-   set_noise_rms_3(value);
-   set_noise_rms_4(value);
-   set_noise_rms_5(value);
-   set_noise_rms_6(value);
-   set_noise_rms_7(value);
-   set_noise_rms_8(value);
-   set_noise_rms_9(value);
-   set_noise_rms_10(value);
-   set_noise_rms_11(value);
-   set_noise_rms_12(value);
-   set_noise_rms_13(value);
-   set_noise_rms_14(value);
-   set_noise_rms_15(value);
-}
-
 void do_init() {
    // emulator controls
    set_emu_rst(1);
@@ -48,8 +22,8 @@ void do_init() {
    set_emu_dec_thr(0);
 
    // noise controls
-   set_jitter_rms(0);
-   set_noise_rms(0);
+   set_jitter_rms_int(0);
+   set_noise_rms_int(0);
 
    // JTAG-specific
    set_tdi(0);
@@ -264,10 +238,10 @@ int main() {
                         sleep_time = arg1;
                         nargs=0;
                     } else if (cmd == SET_NOISE_RMS) {
-                        set_noise_rms(arg1);
+                        set_noise_rms_int(arg1);
                         nargs=0;
                     } else if (cmd == SET_JITTER_RMS) {
-                        set_jitter_rms(arg1);
+                        set_jitter_rms_int(arg1);
                         nargs=0;
                     } else {
                         nargs++;

--- a/tests/fpga_system_tests/emu/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu/sim_ctrl.sv
@@ -14,6 +14,8 @@ module sim_ctrl(
     output reg tms=1'b1,
     output reg trst_n=1'b0,
     output reg dump_start=1'b0,
+    output reg [6:0] jitter_rms_int,
+    output reg [10:0] noise_rms_int,
     input wire tdo
 );
 	import const_pack::*;
@@ -54,6 +56,10 @@ module sim_ctrl(
     endtask
 
     initial begin
+        // TODO: explore jitter/noise effect
+        jitter_rms_int = 0;
+        noise_rms_int = 0;
+
         // wait for emulator reset to complete
         $display("Waiting for emulator reset to complete...");
         #((50.0/(`EMU_CLK_FREQ))*1s);

--- a/tests/fpga_system_tests/emu/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu/sim_ctrl.sv
@@ -14,8 +14,26 @@ module sim_ctrl(
     output reg tms=1'b1,
     output reg trst_n=1'b0,
     output reg dump_start=1'b0,
-    output reg [6:0] jitter_rms_int,
-    output reg [10:0] noise_rms_int,
+    output reg [6:0] jitter_rms_0,
+    output reg [6:0] jitter_rms_1,
+    output reg [6:0] jitter_rms_2,
+    output reg [6:0] jitter_rms_3,
+    output reg [10:0] noise_rms_0,
+    output reg [10:0] noise_rms_1,
+    output reg [10:0] noise_rms_2,
+    output reg [10:0] noise_rms_3,
+    output reg [10:0] noise_rms_4,
+    output reg [10:0] noise_rms_5,
+    output reg [10:0] noise_rms_6,
+    output reg [10:0] noise_rms_7,
+    output reg [10:0] noise_rms_8,
+    output reg [10:0] noise_rms_9,
+    output reg [10:0] noise_rms_10,
+    output reg [10:0] noise_rms_11,
+    output reg [10:0] noise_rms_12,
+    output reg [10:0] noise_rms_13,
+    output reg [10:0] noise_rms_14,
+    output reg [10:0] noise_rms_15,
     input wire tdo
 );
 	import const_pack::*;
@@ -55,10 +73,31 @@ module sim_ctrl(
         #((200.0/(`EMU_CLK_FREQ))*1s);
     endtask
 
+    localparam [6:0] jitter_rms = 0;
+    localparam [10:0] noise_rms = 0;
+
     initial begin
         // TODO: explore jitter/noise effect
-        jitter_rms_int = 0;
-        noise_rms_int = 0;
+        jitter_rms_0 = jitter_rms;
+        jitter_rms_1 = jitter_rms;
+        jitter_rms_2 = jitter_rms;
+        jitter_rms_3 = jitter_rms;
+        noise_rms_0 = noise_rms;
+        noise_rms_1 = noise_rms;
+        noise_rms_2 = noise_rms;
+        noise_rms_3 = noise_rms;
+        noise_rms_4 = noise_rms;
+        noise_rms_5 = noise_rms;
+        noise_rms_6 = noise_rms;
+        noise_rms_7 = noise_rms;
+        noise_rms_8 = noise_rms;
+        noise_rms_9 = noise_rms;
+        noise_rms_10 = noise_rms;
+        noise_rms_11 = noise_rms;
+        noise_rms_12 = noise_rms;
+        noise_rms_13 = noise_rms;
+        noise_rms_14 = noise_rms;
+        noise_rms_15 = noise_rms;
 
         // wait for emulator reset to complete
         $display("Waiting for emulator reset to complete...");

--- a/tests/fpga_system_tests/emu/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu/sim_ctrl.sv
@@ -14,26 +14,8 @@ module sim_ctrl(
     output reg tms=1'b1,
     output reg trst_n=1'b0,
     output reg dump_start=1'b0,
-    output reg [6:0] jitter_rms_0,
-    output reg [6:0] jitter_rms_1,
-    output reg [6:0] jitter_rms_2,
-    output reg [6:0] jitter_rms_3,
-    output reg [10:0] noise_rms_0,
-    output reg [10:0] noise_rms_1,
-    output reg [10:0] noise_rms_2,
-    output reg [10:0] noise_rms_3,
-    output reg [10:0] noise_rms_4,
-    output reg [10:0] noise_rms_5,
-    output reg [10:0] noise_rms_6,
-    output reg [10:0] noise_rms_7,
-    output reg [10:0] noise_rms_8,
-    output reg [10:0] noise_rms_9,
-    output reg [10:0] noise_rms_10,
-    output reg [10:0] noise_rms_11,
-    output reg [10:0] noise_rms_12,
-    output reg [10:0] noise_rms_13,
-    output reg [10:0] noise_rms_14,
-    output reg [10:0] noise_rms_15,
+    output reg [6:0] jitter_rms_int,
+    output reg [10:0] noise_rms_int,
     input wire tdo
 );
 	import const_pack::*;
@@ -73,31 +55,10 @@ module sim_ctrl(
         #((200.0/(`EMU_CLK_FREQ))*1s);
     endtask
 
-    localparam [6:0] jitter_rms = 0;
-    localparam [10:0] noise_rms = 0;
-
     initial begin
         // TODO: explore jitter/noise effect
-        jitter_rms_0 = jitter_rms;
-        jitter_rms_1 = jitter_rms;
-        jitter_rms_2 = jitter_rms;
-        jitter_rms_3 = jitter_rms;
-        noise_rms_0 = noise_rms;
-        noise_rms_1 = noise_rms;
-        noise_rms_2 = noise_rms;
-        noise_rms_3 = noise_rms;
-        noise_rms_4 = noise_rms;
-        noise_rms_5 = noise_rms;
-        noise_rms_6 = noise_rms;
-        noise_rms_7 = noise_rms;
-        noise_rms_8 = noise_rms;
-        noise_rms_9 = noise_rms;
-        noise_rms_10 = noise_rms;
-        noise_rms_11 = noise_rms;
-        noise_rms_12 = noise_rms;
-        noise_rms_13 = noise_rms;
-        noise_rms_14 = noise_rms;
-        noise_rms_15 = noise_rms;
+        jitter_rms_int = 0;
+        noise_rms_int = 0;
 
         // wait for emulator reset to complete
         $display("Waiting for emulator reset to complete...");

--- a/tests/fpga_system_tests/emu/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu/sim_ctrl.sv
@@ -124,6 +124,10 @@ module sim_ctrl(
         `FORCE_JTAG(retimer_mux_ctrl_2, 16'hFFFF);
         #((25.0/(`EMU_CLK_FREQ))*1s);
 
+        // Assert the CDR reset
+        `FORCE_JTAG(cdr_rstb, 0);
+        #((25.0/(`EMU_CLK_FREQ))*1s);
+
         // Configure the CDR
         $display("Configuring the CDR...");
         `FORCE_JTAG(Kp, 18);
@@ -139,6 +143,10 @@ module sim_ctrl(
         `FORCE_JTAG(en_v2t, 0);
         #((25.0/(`EMU_CLK_FREQ))*1s);
         `FORCE_JTAG(en_v2t, 1);
+        #((25.0/(`EMU_CLK_FREQ))*1s);
+
+        // De-assert the CDR reset
+        `FORCE_JTAG(cdr_rstb, 1);
         #((25.0/(`EMU_CLK_FREQ))*1s);
 
         // Wait for PRBS checker to lock

--- a/tests/fpga_system_tests/emu/simctrl.yaml
+++ b/tests/fpga_system_tests/emu/simctrl.yaml
@@ -23,6 +23,14 @@ digital_ctrl_inputs:
     abspath: 'tb_i.trst_n'
     width: 1
     init_value: 0
+  jitter_rms_int:
+    abspath: 'tb_i.jitter_rms_int'
+    width: 7
+    init_value: 0
+  noise_rms_int:
+    abspath: 'tb_i.noise_rms_int'
+    width: 11
+    init_value: 0
 digital_ctrl_outputs:
   tdo:
     abspath: 'tb_i.tdo'

--- a/tests/fpga_system_tests/emu/simctrl.yaml
+++ b/tests/fpga_system_tests/emu/simctrl.yaml
@@ -23,12 +23,84 @@ digital_ctrl_inputs:
     abspath: 'tb_i.trst_n'
     width: 1
     init_value: 0
-  jitter_rms_int:
-    abspath: 'tb_i.jitter_rms_int'
+  jitter_rms_0:
+    abspath: 'tb_i.top_i.iacore.iPI[0].iPI.jitter_rms_int'
     width: 7
     init_value: 0
-  noise_rms_int:
-    abspath: 'tb_i.noise_rms_int'
+  jitter_rms_1:
+    abspath: 'tb_i.top_i.iacore.iPI[1].iPI.jitter_rms_int'
+    width: 7
+    init_value: 0
+  jitter_rms_2:
+    abspath: 'tb_i.top_i.iacore.iPI[2].iPI.jitter_rms_int'
+    width: 7
+    init_value: 0
+  jitter_rms_3:
+    abspath: 'tb_i.top_i.iacore.iPI[3].iPI.jitter_rms_int'
+    width: 7
+    init_value: 0
+  noise_rms_0:
+    abspath: 'tb_i.top_i.iacore.iADC[0].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_1:
+    abspath: 'tb_i.top_i.iacore.iADC[1].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_2:
+    abspath: 'tb_i.top_i.iacore.iADC[2].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_3:
+    abspath: 'tb_i.top_i.iacore.iADC[3].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_4:
+    abspath: 'tb_i.top_i.iacore.iADC[4].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_5:
+    abspath: 'tb_i.top_i.iacore.iADC[5].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_6:
+    abspath: 'tb_i.top_i.iacore.iADC[6].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_7:
+    abspath: 'tb_i.top_i.iacore.iADC[7].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_8:
+    abspath: 'tb_i.top_i.iacore.iADC[8].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_9:
+    abspath: 'tb_i.top_i.iacore.iADC[9].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_10:
+    abspath: 'tb_i.top_i.iacore.iADC[10].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_11:
+    abspath: 'tb_i.top_i.iacore.iADC[11].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_12:
+    abspath: 'tb_i.top_i.iacore.iADC[12].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_13:
+    abspath: 'tb_i.top_i.iacore.iADC[13].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_14:
+    abspath: 'tb_i.top_i.iacore.iADC[14].iADC.noise_rms_int'
+    width: 11
+    init_value: 0
+  noise_rms_15:
+    abspath: 'tb_i.top_i.iacore.iADC[15].iADC.noise_rms_int'
     width: 11
     init_value: 0
 digital_ctrl_outputs:

--- a/tests/fpga_system_tests/emu/simctrl.yaml
+++ b/tests/fpga_system_tests/emu/simctrl.yaml
@@ -23,84 +23,12 @@ digital_ctrl_inputs:
     abspath: 'tb_i.trst_n'
     width: 1
     init_value: 0
-  jitter_rms_0:
-    abspath: 'tb_i.top_i.iacore.iPI[0].iPI.jitter_rms_int'
+  jitter_rms_int:
+    abspath: 'tb_i.jitter_rms_int'
     width: 7
     init_value: 0
-  jitter_rms_1:
-    abspath: 'tb_i.top_i.iacore.iPI[1].iPI.jitter_rms_int'
-    width: 7
-    init_value: 0
-  jitter_rms_2:
-    abspath: 'tb_i.top_i.iacore.iPI[2].iPI.jitter_rms_int'
-    width: 7
-    init_value: 0
-  jitter_rms_3:
-    abspath: 'tb_i.top_i.iacore.iPI[3].iPI.jitter_rms_int'
-    width: 7
-    init_value: 0
-  noise_rms_0:
-    abspath: 'tb_i.top_i.iacore.iADC[0].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_1:
-    abspath: 'tb_i.top_i.iacore.iADC[1].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_2:
-    abspath: 'tb_i.top_i.iacore.iADC[2].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_3:
-    abspath: 'tb_i.top_i.iacore.iADC[3].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_4:
-    abspath: 'tb_i.top_i.iacore.iADC[4].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_5:
-    abspath: 'tb_i.top_i.iacore.iADC[5].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_6:
-    abspath: 'tb_i.top_i.iacore.iADC[6].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_7:
-    abspath: 'tb_i.top_i.iacore.iADC[7].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_8:
-    abspath: 'tb_i.top_i.iacore.iADC[8].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_9:
-    abspath: 'tb_i.top_i.iacore.iADC[9].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_10:
-    abspath: 'tb_i.top_i.iacore.iADC[10].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_11:
-    abspath: 'tb_i.top_i.iacore.iADC[11].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_12:
-    abspath: 'tb_i.top_i.iacore.iADC[12].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_13:
-    abspath: 'tb_i.top_i.iacore.iADC[13].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_14:
-    abspath: 'tb_i.top_i.iacore.iADC[14].iADC.noise_rms_int'
-    width: 11
-    init_value: 0
-  noise_rms_15:
-    abspath: 'tb_i.top_i.iacore.iADC[15].iADC.noise_rms_int'
+  noise_rms_int:
+    abspath: 'tb_i.noise_rms_int'
     width: 11
     init_value: 0
 digital_ctrl_outputs:

--- a/tests/fpga_system_tests/emu/simvision.svcf
+++ b/tests/fpga_system_tests/emu/simvision.svcf
@@ -1,0 +1,106 @@
+# SimVision Command Script (Wed Jul 15 05:25:01 PM PDT 2020)
+#
+# Version 19.03.s003
+#
+# You can restore this configuration with:
+#
+#     simvision -input /home/sherbst/Code/dragonphy2/tests/fpga_system_tests/emu/simvision.svcf
+#  or simvision -input /home/sherbst/Code/dragonphy2/tests/fpga_system_tests/emu/simvision.svcf database1 database2 ...
+#
+
+
+#
+# Preferences
+#
+preferences set plugin-enable-svdatabrowser-new 1
+preferences set toolbar-Standard-Console {
+  usual
+  position -pos 1
+}
+preferences set toolbar-Search-Console {
+  usual
+  position -pos 2
+}
+preferences set toolbar-Standard-WaveWindow {
+  usual
+  position -pos 1
+}
+preferences set plugin-enable-groupscope 0
+preferences set plugin-enable-interleaveandcompare 0
+preferences set plugin-enable-waveformfrequencyplot 0
+preferences set whats-new-dont-show-at-startup 1
+
+#
+# Databases
+#
+array set dbNames ""
+set dbNames(realName1) [ database require top_sim -hints {
+	file ./tests/fpga_system_tests/emu/build/sim/raw_results/top_sim.trn
+	file /home/sherbst/Code/dragonphy2/tests/fpga_system_tests/emu/build/sim/raw_results/top_sim.trn
+}]
+if {$dbNames(realName1) == ""} {
+    set dbNames(realName1) top_sim
+}
+
+#
+# Mnemonic Maps
+#
+mmap new  -reuse -name {Boolean as Logic} -radix %b -contents {{%c=FALSE -edgepriority 1 -shape low}
+{%c=TRUE -edgepriority 1 -shape high}}
+mmap new  -reuse -name {Example Map} -radix %x -contents {{%b=11???? -bgcolor orange -label REG:%x -linecolor yellow -shape bus}
+{%x=1F -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=2C -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=* -label %x -linecolor gray -shape bus}}
+
+#
+# Waveform windows
+#
+if {[catch {window new WaveWindow -name "Waveform 1" -geometry 1311x563+48+62}] != ""} {
+    window geometry "Waveform 1" 1311x563+48+62
+}
+window target "Waveform 1" on
+waveform using {Waveform 1}
+waveform sidebar select designbrowser
+waveform set \
+    -primarycursor TimeA \
+    -signalnames name \
+    -signalwidth 175 \
+    -units fs \
+    -valuewidth 75
+waveform baseline set -time 18,960,190,546,529fs
+
+set id [waveform add -signals [subst  {
+	{$dbNames(realName1)::[format {top.trace_port_gen_i.ctl_pi_0[8:0]}]}
+	} ]]
+waveform format $id -trace analogSampleAndHold
+waveform axis range $id -for default -min 0 -max 65 -scale linear
+set id [waveform add -signals [subst  {
+	{$dbNames(realName1)::[format {top.trace_port_gen_i.emu_dec_cmp}]}
+	} ]]
+set id [waveform add -signals [subst  {
+	{[format {signed(%s::top.trace_port_gen_i.adcout_unfolded_0)}  $dbNames(realName1)]}
+	} ]]
+waveform format $id -radix %d -trace analogSampleAndHold
+waveform axis range $id -for default -min -127 -max 126 -scale linear
+set id [waveform add -signals [subst  {
+	{[format {signed(%s::top.trace_port_gen_i.estimated_bits_0)}  $dbNames(realName1)]}
+	} ]]
+waveform format $id -radix %d -trace analogSampleAndHold
+waveform axis range $id -for default -min -256 -max 161 -scale linear
+
+waveform xview limits 19206942272319fs 21357754772319fs
+
+#
+# Waveform Window Links
+#
+
+#
+# Console windows
+#
+console set -windowname Console
+window geometry Console 600x250+73+102
+
+#
+# Layout selection
+#
+

--- a/tests/fpga_system_tests/emu/tb.sv
+++ b/tests/fpga_system_tests/emu/tb.sv
@@ -33,6 +33,8 @@ module tb;
     (* dont_touch = "true" *) logic emu_clk;
     (* dont_touch = "true" *) `DECL_DT(emu_dt);
     (* dont_touch = "true" *) `DECL_DT(dt_req);
+    (* dont_touch = "true" *) logic [6:0] jitter_rms_int;
+    (* dont_touch = "true" *) logic [10:0] noise_rms_int;
 
     //////////////
     // TX clock //
@@ -165,13 +167,38 @@ module tb;
         .out(data_tx_i)
     );
 
-    /////////////////////
-    // Configure PRNGs //
-    /////////////////////
+    ///////////////
+    // ADC noise //
+    ///////////////
 
+    // calculate scale factor
+    `MAKE_REAL(noise_rms, 250e-3);
+    `INT_TO_REAL({1'b0, noise_rms_int}, 12, noise_rms_real);
+    `MUL_CONST_INTO_REAL(0.1e-3, noise_rms_real, noise_rms);
 
-    // ADC noise (seeds from random.org)
+    // write scale factor into hierarchy
+    // value for each ADC is set separately due to synthesis limitations;
+    // putting these assignments in a generate loop seems to create a
+    // multiply-driven net.
+    assign tb_i.top_i.iacore.iADC[0].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[1].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[2].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[3].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[4].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[5].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[6].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[7].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[8].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[9].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[10].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[11].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[12].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[13].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[14].iADC.noise_rms = noise_rms;
+    assign tb_i.top_i.iacore.iADC[15].iADC.noise_rms = noise_rms;
 
+    // set random seeds (from random.org)
+    // each parameter is set separately due to synthesis limitations
     defparam top_i.iacore.iADC[0].iADC.rx_adc_core_i.noise_seed = 32'd61349;
     defparam top_i.iacore.iADC[1].iADC.rx_adc_core_i.noise_seed = 32'd8335;
     defparam top_i.iacore.iADC[2].iADC.rx_adc_core_i.noise_seed = 32'd9132;
@@ -189,8 +216,26 @@ module tb;
     defparam top_i.iacore.iADC[14].iADC.rx_adc_core_i.noise_seed = 32'd60972;
     defparam top_i.iacore.iADC[15].iADC.rx_adc_core_i.noise_seed = 32'd65135;
 
-    // PI jitter (seeds from random.org)
+    ///////////////
+    // PI jitter //
+    ///////////////
 
+    // calculate scale factor
+    `MAKE_REAL(jitter_rms, 15e-12);
+    `INT_TO_REAL({1'b0, jitter_rms_int}, 8, jitter_rms_real);
+    `MUL_CONST_INTO_REAL(0.1e-12, jitter_rms_real, jitter_rms);
+
+    // write scale factor into hierarchy
+    // value for each PI is set separately due to synthesis limitations;
+    // putting these assignments in a generate loop seems to create a
+    // multiply-driven net.
+    assign tb_i.top_i.iacore.iPI[0].iPI.jitter_rms = jitter_rms;
+    assign tb_i.top_i.iacore.iPI[1].iPI.jitter_rms = jitter_rms;
+    assign tb_i.top_i.iacore.iPI[2].iPI.jitter_rms = jitter_rms;
+    assign tb_i.top_i.iacore.iPI[3].iPI.jitter_rms = jitter_rms;
+
+    // set random seeds (from random.org)
+    // each parameter is set explicitly due to synthesis limitations
     defparam top_i.iacore.iPI[0].iPI.clk_delay_core_i.jitter_seed = 32'd8485;
     defparam top_i.iacore.iPI[1].iPI.clk_delay_core_i.jitter_seed = 32'd25439;
     defparam top_i.iacore.iPI[2].iPI.clk_delay_core_i.jitter_seed = 32'd1655;

--- a/tests/fpga_system_tests/emu/tb.sv
+++ b/tests/fpga_system_tests/emu/tb.sv
@@ -180,22 +180,22 @@ module tb;
     // value for each ADC is set separately due to synthesis limitations;
     // putting these assignments in a generate loop seems to create a
     // multiply-driven net.
-    assign tb_i.top_i.iacore.iADC[0].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[1].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[2].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[3].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[4].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[5].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[6].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[7].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[8].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[9].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[10].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[11].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[12].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[13].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[14].iADC.noise_rms = noise_rms;
-    assign tb_i.top_i.iacore.iADC[15].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[0].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[1].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[2].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[3].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[4].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[5].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[6].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[7].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[8].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[9].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[10].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[11].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[12].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[13].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[14].iADC.noise_rms = noise_rms;
+    assign top_i.iacore.iADC[15].iADC.noise_rms = noise_rms;
 
     // set random seeds (from random.org)
     // each parameter is set separately due to synthesis limitations
@@ -229,10 +229,10 @@ module tb;
     // value for each PI is set separately due to synthesis limitations;
     // putting these assignments in a generate loop seems to create a
     // multiply-driven net.
-    assign tb_i.top_i.iacore.iPI[0].iPI.jitter_rms = jitter_rms;
-    assign tb_i.top_i.iacore.iPI[1].iPI.jitter_rms = jitter_rms;
-    assign tb_i.top_i.iacore.iPI[2].iPI.jitter_rms = jitter_rms;
-    assign tb_i.top_i.iacore.iPI[3].iPI.jitter_rms = jitter_rms;
+    assign top_i.iacore.iPI[0].iPI.jitter_rms = jitter_rms;
+    assign top_i.iacore.iPI[1].iPI.jitter_rms = jitter_rms;
+    assign top_i.iacore.iPI[2].iPI.jitter_rms = jitter_rms;
+    assign top_i.iacore.iPI[3].iPI.jitter_rms = jitter_rms;
 
     // set random seeds (from random.org)
     // each parameter is set explicitly due to synthesis limitations

--- a/tests/fpga_system_tests/emu/tb.sv
+++ b/tests/fpga_system_tests/emu/tb.sv
@@ -9,35 +9,33 @@ module tb;
     (* dont_touch = "true" *) logic dump_start;
 
     (* dont_touch = "true" *) logic tdi;
-	(* dont_touch = "true" *) logic tdo;
-	(* dont_touch = "true" *) logic tck;
-	(* dont_touch = "true" *) logic tms;
-	(* dont_touch = "true" *) logic trst_n;
+    (* dont_touch = "true" *) logic tdo;
+    (* dont_touch = "true" *) logic tck;
+    (* dont_touch = "true" *) logic tms;
+    (* dont_touch = "true" *) logic trst_n;
 
     ////////////////////
-	// JTAG Interface //
-	////////////////////
+    // JTAG Interface //
+    ////////////////////
 
-	jtag_intf jtag_intf_i ();
-	assign jtag_intf_i.phy_tdi = tdi;
+    jtag_intf jtag_intf_i ();
+    assign jtag_intf_i.phy_tdi = tdi;
     assign tdo = jtag_intf_i.phy_tdo;
     assign jtag_intf_i.phy_tck = tck;
     assign jtag_intf_i.phy_tms = tms;
     assign jtag_intf_i.phy_trst_n = trst_n;
 
     ////////////////////
-	//  Emulator I/O  //
-	////////////////////
+    //  Emulator I/O  //
+    ////////////////////
 
     (* dont_touch = "true" *) logic emu_rst;
     (* dont_touch = "true" *) logic emu_clk;
     (* dont_touch = "true" *) `DECL_DT(emu_dt);
     (* dont_touch = "true" *) `DECL_DT(dt_req);
-    (* dont_touch = "true" *) logic [6:0] jitter_rms_int;
-    (* dont_touch = "true" *) logic [10:0] noise_rms_int;
 
     //////////////
-	// TX clock //
+    // TX clock //
     //////////////
 
     (* dont_touch = "true" *) logic clk_tx_val_posedge;
@@ -107,8 +105,8 @@ module tb;
     );
 
     ///////////////////
-	// Clock divider //
-	///////////////////
+    // Clock divider //
+    ///////////////////
 
     (* dont_touch = "true" *) logic ext_clkp;
 
@@ -126,13 +124,13 @@ module tb;
     end
 
     ////////////////
-	// Top module //
-	////////////////
+    // Top module //
+    ////////////////
 
-	(* dont_touch = "true" *) dragonphy_top top_i (
-	    // analog inputs
-		.ext_rx_inp(data_rx_i),
-		.ext_rx_inn(0),
+    (* dont_touch = "true" *) dragonphy_top top_i (
+        // analog inputs
+        .ext_rx_inp(data_rx_i),
+        .ext_rx_inn(0),
 
         // clock inputs
         .ext_clkp(ext_clkp),
@@ -145,10 +143,10 @@ module tb;
         .ext_dump_start(dump_start),
 
         // JTAG
-		.jtag_intf_i(jtag_intf_i)
+        .jtag_intf_i(jtag_intf_i)
 
-		// other I/O not used..
-	);
+        // other I/O not used..
+    );
 
     //////////
     // PRBS //
@@ -168,37 +166,34 @@ module tb;
     );
 
     /////////////////////
-	// Configure PRNGs //
-	/////////////////////
+    // Configure PRNGs //
+    /////////////////////
 
-    genvar i;
 
     // ADC noise (seeds from random.org)
 
-    localparam [31:0] noise_seed [16] = '{32'd61349, 32'd8335, 32'd9132, 32'd25683, 32'd13215, 32'd15813, 32'd48824, 32'd37609, 32'd36034, 32'd37264, 32'd50609, 32'd56017, 32'd36602, 32'd46638, 32'd60972, 32'd65135};
-
-    generate
-        for (i=0; i<16; i=i+1) begin
-            // define noise seed
-            defparam top_i.iacore.iADC[i].iADC.noise_seed = noise_seed[i];
-
-            // wire up the noise control signal
-            assign top_i.iacore.iADC[i].iADC.noise_rms_int = noise_rms_int;
-        end
-    endgenerate
+    defparam top_i.iacore.iADC[0].iADC.rx_adc_core_i.noise_seed = 32'd61349;
+    defparam top_i.iacore.iADC[1].iADC.rx_adc_core_i.noise_seed = 32'd8335;
+    defparam top_i.iacore.iADC[2].iADC.rx_adc_core_i.noise_seed = 32'd9132;
+    defparam top_i.iacore.iADC[3].iADC.rx_adc_core_i.noise_seed = 32'd25683;
+    defparam top_i.iacore.iADC[4].iADC.rx_adc_core_i.noise_seed = 32'd13215;
+    defparam top_i.iacore.iADC[5].iADC.rx_adc_core_i.noise_seed = 32'd15813;
+    defparam top_i.iacore.iADC[6].iADC.rx_adc_core_i.noise_seed = 32'd48824;
+    defparam top_i.iacore.iADC[7].iADC.rx_adc_core_i.noise_seed = 32'd37609;
+    defparam top_i.iacore.iADC[8].iADC.rx_adc_core_i.noise_seed = 32'd36034;
+    defparam top_i.iacore.iADC[9].iADC.rx_adc_core_i.noise_seed = 32'd37264;
+    defparam top_i.iacore.iADC[10].iADC.rx_adc_core_i.noise_seed = 32'd50609;
+    defparam top_i.iacore.iADC[11].iADC.rx_adc_core_i.noise_seed = 32'd56017;
+    defparam top_i.iacore.iADC[12].iADC.rx_adc_core_i.noise_seed = 32'd36602;
+    defparam top_i.iacore.iADC[13].iADC.rx_adc_core_i.noise_seed = 32'd46638;
+    defparam top_i.iacore.iADC[14].iADC.rx_adc_core_i.noise_seed = 32'd60972;
+    defparam top_i.iacore.iADC[15].iADC.rx_adc_core_i.noise_seed = 32'd65135;
 
     // PI jitter (seeds from random.org)
 
-    localparam [31:0] jitter_seed [4] = '{32'd8485, 32'd25439, 32'd1655, 32'd2550};
-
-    generate
-        for (i=0; i<4; i=i+1) begin
-            // define jitter seed
-            defparam top_i.iacore.iPI[i].iPI.jitter_seed = jitter_seed[i];
-
-            // wire up the jitter control signal
-            assign top_i.iacore.iPI[i].iPI.jitter_rms_int = jitter_rms_int;
-        end
-    endgenerate
+    defparam top_i.iacore.iPI[0].iPI.clk_delay_core_i.jitter_seed = 32'd8485;
+    defparam top_i.iacore.iPI[1].iPI.clk_delay_core_i.jitter_seed = 32'd25439;
+    defparam top_i.iacore.iPI[2].iPI.clk_delay_core_i.jitter_seed = 32'd1655;
+    defparam top_i.iacore.iPI[3].iPI.clk_delay_core_i.jitter_seed = 32'd2550;
 
 endmodule

--- a/tests/fpga_system_tests/emu/tb.sv
+++ b/tests/fpga_system_tests/emu/tb.sv
@@ -33,6 +33,8 @@ module tb;
     (* dont_touch = "true" *) logic emu_clk;
     (* dont_touch = "true" *) `DECL_DT(emu_dt);
     (* dont_touch = "true" *) `DECL_DT(dt_req);
+    (* dont_touch = "true" *) logic [6:0] jitter_rms_int;
+    (* dont_touch = "true" *) logic [10:0] noise_rms_int;
 
     //////////////
 	// TX clock //
@@ -164,5 +166,39 @@ module tb;
         .inv_chicken(2'b00),
         .out(data_tx_i)
     );
+
+    /////////////////////
+	// Configure PRNGs //
+	/////////////////////
+
+    genvar i;
+
+    // ADC noise (seeds from random.org)
+
+    localparam [31:0] noise_seed [16] = '{32'd61349, 32'd8335, 32'd9132, 32'd25683, 32'd13215, 32'd15813, 32'd48824, 32'd37609, 32'd36034, 32'd37264, 32'd50609, 32'd56017, 32'd36602, 32'd46638, 32'd60972, 32'd65135};
+
+    generate
+        for (i=0; i<16; i=i+1) begin
+            // define noise seed
+            defparam top_i.iacore.iADC[i].iADC.noise_seed = noise_seed[i];
+
+            // wire up the noise control signal
+            assign top_i.iacore.iADC[i].iADC.noise_rms_int = noise_rms_int;
+        end
+    endgenerate
+
+    // PI jitter (seeds from random.org)
+
+    localparam [31:0] jitter_seed [4] = '{32'd8485, 32'd25439, 32'd1655, 32'd2550};
+
+    generate
+        for (i=0; i<4; i=i+1) begin
+            // define jitter seed
+            defparam top_i.iacore.iPI[i].iPI.jitter_seed = jitter_seed[i];
+
+            // wire up the jitter control signal
+            assign top_i.iacore.iPI[i].iPI.jitter_rms_int = jitter_rms_int;
+        end
+    endgenerate
 
 endmodule

--- a/tests/fpga_system_tests/emu/test_emu.py
+++ b/tests/fpga_system_tests/emu/test_emu.py
@@ -295,6 +295,7 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur):
 
     # Configure the CDR
     print('Configuring the CDR...')
+    write_tc_reg('cdr_rstb', 0)
     write_tc_reg('Kp', 15)
     write_tc_reg('Ki', 0)
     write_tc_reg('invert', 1)
@@ -307,8 +308,11 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur):
     write_tc_reg('en_v2t', 0)
     write_tc_reg('en_v2t', 1)
 
-    # Wait for CDR to lock
-    print('Wait for PRBS checker to lock')
+    # Release the CDR from reset, then wait for it to lock
+    # TODO: explore why it is not sufficient to pulse cdr_rstb low here
+    # (i.e., seems that it must be set to zero while configuring CDR parameters
+    print('Wait for the CDR to lock')
+    write_tc_reg('cdr_rstb', 1)
     time.sleep(1.0)
 
     # Run PRBS test.  In order to get a conservative estimate for the throughput, the

--- a/tests/fpga_system_tests/emu/test_emu.py
+++ b/tests/fpga_system_tests/emu/test_emu.py
@@ -44,7 +44,6 @@ def test_1(board_name, emu_clk_freq, flatten_hierarchy):
     src_cfg.add_defines({'VIVADO': None})
     src_cfg.add_defines({'DT_EXPONENT': -46})  # TODO: move to DT_SCALE
     src_cfg.add_defines({'GIT_HASH': str(get_git_hash_short())}, fileset='sim')
-    src_cfg.add_defines({'LONG_WIDTH_REAL': 32})
 
     # Firmware
     src_cfg.add_firmware_files([THIS_DIR / 'main.c'])

--- a/tests/fpga_system_tests/emu/test_emu.py
+++ b/tests/fpga_system_tests/emu/test_emu.py
@@ -148,12 +148,9 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_
     def shift_ir(val, width):
         ser.write(f'SIR {val} {width}\n'.encode('utf-8'))
 
-    def shift_dr(val, width, expect_output=False):
-        if expect_output:
-            ser.write(f'SDR {val} {width}\n'.encode('utf-8'))
-            return int(ser.readline().strip())
-        else:
-            ser.write(f'QSDR {val} {width}\n'.encode('utf-8'))
+    def shift_dr(val, width):
+        ser.write(f'SDR {val} {width}\n'.encode('utf-8'))
+        return int(ser.readline().strip())
 
     def write_tc_reg(name, val):
         # specify address
@@ -192,7 +189,7 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_
 
         # get data
         shift_ir(tc_cfg_data, jtag_inst_width)
-        return shift_dr(0, tc_bus_width, expect_output=True)
+        return shift_dr(0, tc_bus_width)
 
     def read_sc_reg(name):
         # specify address
@@ -205,7 +202,7 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_
 
         # get data
         shift_ir(sc_cfg_data, jtag_inst_width)
-        return shift_dr(0, sc_bus_width, expect_output=True)
+        return shift_dr(0, sc_bus_width)
 
     def load_weight(
             d_idx, # clog2(ffe_length)
@@ -261,7 +258,7 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_
     # read the ID
     print('Reading ID...')
     shift_ir(1, 5)
-    id_result = shift_dr(0, 32, expect_output=True)
+    id_result = shift_dr(0, 32)
     print(f'ID: {id_result}')
 
     # Set PFD offset

--- a/tests/fpga_system_tests/emu_macro/main.c
+++ b/tests/fpga_system_tests/emu_macro/main.c
@@ -268,10 +268,10 @@ int main() {
                         set_trst_n(arg1);
                         nargs=0;
                     } else if (cmd == SET_NOISE_RMS) {
-                        set_noise_rms(arg1);
+                        set_noise_rms_int(arg1);
                         nargs=0;
                     } else if (cmd == SET_JITTER_RMS) {
-                        set_jitter_rms(arg1);
+                        set_jitter_rms_int(arg1);
                         nargs=0;
                     } else if (cmd == SET_SLEEP) {
                         sleep_time = arg1;

--- a/tests/fpga_system_tests/emu_macro/main.c
+++ b/tests/fpga_system_tests/emu_macro/main.c
@@ -21,6 +21,10 @@ void do_init() {
    set_emu_ctrl_data(0);
    set_emu_dec_thr(0);
 
+   // noise controls
+   set_jitter_rms_int(0);
+   set_noise_rms_int(0);
+
    // JTAG-specific
    set_tdi(0);
    set_tck(0);
@@ -154,7 +158,9 @@ enum cmd_t {
     SET_TCK,
     SET_TMS,
     SET_TRST_N,
-    GET_TDO
+    GET_TDO,
+    SET_NOISE_RMS,
+    SET_JITTER_RMS
 } cmd;
 
 int main() {
@@ -228,6 +234,12 @@ int main() {
                     } else if (strcmp(buf, "SET_TRST_N") == 0) {
                         cmd = SET_TRST_N;
                         nargs++;
+                    } else if (strcmp(buf, "SET_NOISE_RMS") == 0) {
+                        cmd = SET_NOISE_RMS;
+                        nargs++;
+                    } else if (strcmp(buf, "SET_JITTER_RMS") == 0) {
+                        cmd = SET_JITTER_RMS;
+                        nargs++;
                     } else if (strcmp(buf, "GET_TDO") == 0) {
                         cmd = GET_TDO;
                         xil_printf("%lu\r\n", get_tdo());
@@ -254,6 +266,12 @@ int main() {
                         nargs=0;
                     } else if (cmd == SET_TRST_N) {
                         set_trst_n(arg1);
+                        nargs=0;
+                    } else if (cmd == SET_NOISE_RMS) {
+                        set_noise_rms(arg1);
+                        nargs=0;
+                    } else if (cmd == SET_JITTER_RMS) {
+                        set_jitter_rms(arg1);
                         nargs=0;
                     } else if (cmd == SET_SLEEP) {
                         sleep_time = arg1;

--- a/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
@@ -14,6 +14,8 @@ module sim_ctrl(
     output reg tms=1'b1,
     output reg trst_n=1'b0,
     output reg dump_start=1'b0,
+    output reg [6:0] jitter_rms_int,
+    output reg [10:0] noise_rms_int,
     input wire tdo
 );
 	import const_pack::*;
@@ -54,6 +56,10 @@ module sim_ctrl(
     endtask
 
     initial begin
+        // TODO: explore jitter/noise effect
+        jitter_rms_int = 0;
+        noise_rms_int = 0;
+
         // wait for emulator reset to complete
         $display("Waiting for emulator reset to complete...");
         #((10.0/(`EMU_CLK_FREQ))*1s);

--- a/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
@@ -124,6 +124,10 @@ module sim_ctrl(
         `FORCE_JTAG(retimer_mux_ctrl_2, 16'hFFFF);
         #((10.0/(`EMU_CLK_FREQ))*1s);
 
+        // Assert the CDR reset
+        `FORCE_JTAG(cdr_rstb, 0);
+        #((25.0/(`EMU_CLK_FREQ))*1s);
+
         // Configure the CDR
         $display("Configuring the CDR...");
         `FORCE_JTAG(Kp, 18);
@@ -140,6 +144,10 @@ module sim_ctrl(
         #((10.0/(`EMU_CLK_FREQ))*1s);
         `FORCE_JTAG(en_v2t, 1);
         #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // De-assert the CDR reset
+        `FORCE_JTAG(cdr_rstb, 1);
+        #((25.0/(`EMU_CLK_FREQ))*1s);
 
         // Wait for PRBS checker to lock
 		$display("Waiting for PRBS checker to lock...");

--- a/tests/fpga_system_tests/emu_macro/simctrl.yaml
+++ b/tests/fpga_system_tests/emu_macro/simctrl.yaml
@@ -23,6 +23,14 @@ digital_ctrl_inputs:
     abspath: 'tb_i.trst_n'
     width: 1
     init_value: 0
+  jitter_rms_int:
+    abspath: 'tb_i.top_i.iacore.jitter_rms_int'
+    width: 7
+    init_value: 0
+  noise_rms_int:
+    abspath: 'tb_i.top_i.iacore.noise_rms_int'
+    width: 11
+    init_value: 0
 digital_ctrl_outputs:
   tdo:
     abspath: 'tb_i.tdo'

--- a/tests/fpga_system_tests/emu_macro/simvision.svcf
+++ b/tests/fpga_system_tests/emu_macro/simvision.svcf
@@ -1,0 +1,97 @@
+# SimVision Command Script (Wed Jul 15 05:30:11 PM PDT 2020)
+#
+# Version 19.03.s003
+#
+# You can restore this configuration with:
+#
+#     simvision -input /home/sherbst/Code/dragonphy2/tests/fpga_system_tests/emu_macro/simvision.svcf
+#  or simvision -input /home/sherbst/Code/dragonphy2/tests/fpga_system_tests/emu_macro/simvision.svcf database1 database2 ...
+#
+
+
+#
+# Preferences
+#
+preferences set plugin-enable-svdatabrowser-new 1
+preferences set toolbar-Standard-Console {
+  usual
+  position -pos 1
+}
+preferences set toolbar-Search-Console {
+  usual
+  position -pos 2
+}
+preferences set toolbar-Standard-WaveWindow {
+  usual
+  position -pos 1
+}
+preferences set plugin-enable-groupscope 0
+preferences set plugin-enable-interleaveandcompare 0
+preferences set plugin-enable-waveformfrequencyplot 0
+preferences set whats-new-dont-show-at-startup 1
+
+#
+# Databases
+#
+array set dbNames ""
+set dbNames(realName1) [ database require top_sim -hints {
+	file ./tests/fpga_system_tests/emu_macro/build/sim/raw_results/top_sim.trn
+	file /home/sherbst/Code/dragonphy2/tests/fpga_system_tests/emu_macro/build/sim/raw_results/top_sim.trn
+}]
+if {$dbNames(realName1) == ""} {
+    set dbNames(realName1) top_sim
+}
+
+#
+# Mnemonic Maps
+#
+mmap new  -reuse -name {Boolean as Logic} -radix %b -contents {{%c=FALSE -edgepriority 1 -shape low}
+{%c=TRUE -edgepriority 1 -shape high}}
+mmap new  -reuse -name {Example Map} -radix %x -contents {{%b=11???? -bgcolor orange -label REG:%x -linecolor yellow -shape bus}
+{%x=1F -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=2C -bgcolor red -label ERROR -linecolor white -shape EVENT}
+{%x=* -label %x -linecolor gray -shape bus}}
+
+#
+# Waveform windows
+#
+if {[catch {window new WaveWindow -name "Waveform 1" -geometry 1311x563+48+62}] != ""} {
+    window geometry "Waveform 1" 1311x563+48+62
+}
+window target "Waveform 1" on
+waveform using {Waveform 1}
+waveform sidebar select designbrowser
+waveform set \
+    -primarycursor TimeA \
+    -signalnames name \
+    -signalwidth 175 \
+    -units fs \
+    -valuewidth 75
+waveform baseline set -time 18,960,190,546,529fs
+
+set id [waveform add -signals [subst  {
+	{$dbNames(realName1)::[format {top.trace_port_gen_i.ctl_pi_0[8:0]}]}
+	} ]]
+waveform format $id -radix %d -trace analogSampleAndHold
+waveform axis range $id -for default -min 0 -max 64 -scale linear
+set id [waveform add -signals [subst  {
+	{[format {signed(%s::top.trace_port_gen_i.adcout_unfolded_0)}  $dbNames(realName1)]}
+	} ]]
+waveform format $id -radix %d -trace analogSampleAndHold
+waveform axis range $id -for default -min -127 -max 127 -scale linear
+set id [waveform add -signals [subst  {
+	{[format {signed(%s::top.trace_port_gen_i.estimated_bits_0)}  $dbNames(realName1)]}
+	} ]]
+waveform format $id -radix %d -trace analogSampleAndHold
+waveform axis range $id -for default -min -127 -max 126 -scale linear
+
+waveform xview limits 1003999804688fs 1160499804688fs
+
+#
+# Waveform Window Links
+#
+
+#
+# Layout selection
+#
+

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -82,7 +82,7 @@ def test_5():
     ana.set_target(target_name='fpga')
     ana.program_firmware()
 
-def test_6(ser_port, ffe_length, prbs_test_dur):
+def test_6(ser_port, ffe_length, prbs_test_dur, jitter_rms, noise_rms):
     jtag_inst_width = 5
     sc_bus_width = 32
     sc_addr_width = 14
@@ -246,8 +246,8 @@ def test_6(ser_port, ffe_length, prbs_test_dur):
     set_rstb(1)
 
     # Configure noise
-    set_jitter_rms(0)
-    set_noise_rms(0)
+    set_jitter_rms(int(round(jitter_rms*1e13)))
+    set_noise_rms(int(round(noise_rms*1e4)))
 
     # Soft reset
     print('Soft reset')

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -135,6 +135,12 @@ def test_6(ser_port, ffe_length, prbs_test_dur):
     def set_rstb(val):
         ser.write(f'SET_RSTB {val}\n'.encode('utf-8'))
 
+    def set_jitter_rms(val):
+        ser.write(f'SET_JITTER_RMS {val}\n'.encode('utf-8'))
+
+    def set_noise_rms(val):
+        ser.write(f'SET_NOISE_RMS {val}\n'.encode('utf-8'))
+
     def set_sleep(val):
         ser.write(f'SET_SLEEP {val}\n'.encode('utf-8'))
 
@@ -238,6 +244,10 @@ def test_6(ser_port, ffe_length, prbs_test_dur):
     # Release other reset signals
     print('Release other reset signals')
     set_rstb(1)
+
+    # Configure noise
+    set_jitter_rms(0)
+    set_noise_rms(0)
 
     # Soft reset
     print('Soft reset')

--- a/vlog/fpga_models/analog_core/analog_core.sv
+++ b/vlog/fpga_models/analog_core/analog_core.sv
@@ -38,15 +38,16 @@ module analog_core import const_pack::*; #(
 
     (* dont_touch = "true" *) logic emu_clk;
     (* dont_touch = "true" *) logic emu_rst;
+    (* dont_touch = "true" *) logic [6:0] jitter_rms_int;
+    (* dont_touch = "true" *) logic [10:0] noise_rms_int;
 
-    // noise / jitter controls
-    // TODO: allow external user control
+    // convert noise / jitter to svreal types
 
-    `MAKE_REAL(jitter_rms, 10e-12);
-    `MAKE_REAL(noise_rms, 10e-3);
+    `INT_TO_REAL({1'b0, jitter_rms_int}, 8, jitter_rms_real);
+    `INT_TO_REAL({1'b0, noise_rms_int}, 12, noise_rms_real);
 
-    `ASSIGN_CONST_REAL(0, jitter_rms);
-    `ASSIGN_CONST_REAL(0, noise_rms);
+    `MUL_CONST_REAL(0.1e-12, jitter_rms_real, jitter_rms);
+    `MUL_CONST_REAL(0.1e-3, noise_rms_real, noise_rms);
 
     // instantiate analog slices
 

--- a/vlog/fpga_models/analog_core/analog_core.sv
+++ b/vlog/fpga_models/analog_core/analog_core.sv
@@ -56,6 +56,10 @@ module analog_core import const_pack::*; #(
     logic incr_sum;
     logic last_cycle;
 
+    // random number seeds generated from random.org
+    localparam [31:0] jitter_seed [Nti] = '{32'd8485, 32'd25439, 32'd1655, 32'd2550, 32'd28814, 32'd19790, 32'd22931, 32'd18230, 32'd26850, 32'd11919, 32'd49789, 32'd57646, 32'd8568, 32'd25180, 32'd9577, 32'd38496};
+    localparam [31:0] noise_seed [Nti] = '{32'd61349, 32'd8335, 32'd9132, 32'd25683, 32'd13215, 32'd15813, 32'd48824, 32'd37609, 32'd36034, 32'd37264, 32'd50609, 32'd56017, 32'd36602, 32'd46638, 32'd60972, 32'd65135};
+
     genvar i;
     generate
         for (i=0; i<Nti; i=i+1) begin
@@ -65,6 +69,8 @@ module analog_core import const_pack::*; #(
 
             // instantiate the slice
             analog_slice #(
+                .jitter_seed(jitter_seed[i]),
+                .noise_seed(noise_seed[i]),
                 `PASS_REAL(jitter_rms, jitter_rms),
                 `PASS_REAL(noise_rms, noise_rms)
             ) analog_slice_i (

--- a/vlog/fpga_models/analog_core/phase_interpolator.sv
+++ b/vlog/fpga_models/analog_core/phase_interpolator.sv
@@ -42,16 +42,12 @@ module phase_interpolator #(
     (* dont_touch = "true" *) `DECL_DT(emu_dt);
     (* dont_touch = "true" *) logic emu_clk;
     (* dont_touch = "true" *) logic emu_rst;
-    (* dont_touch = "true" *) logic [6:0] jitter_rms_int;
+    (* dont_touch = "true" *) `MAKE_REAL(jitter_rms, 15e-12);
 
     // declare signal for max timestep
     // TODO: make compatible with FLOAT_REAL
     (* dont_touch = "true" *) `DECL_DT(dt_req_max);
     assign dt_req_max = {1'b0, {((`DT_WIDTH)-1){1'b1}}};
-
-    // convert jitter to an svreal type
-    `INT_TO_REAL({1'b0, jitter_rms_int}, 8, jitter_rms_real);
-    `MUL_CONST_REAL(0.1e-12, jitter_rms_real, jitter_rms);
 
     // instantiate MSDSL model, passing through format information
     clk_delay_core #(

--- a/vlog/fpga_models/analog_core/phase_interpolator.sv
+++ b/vlog/fpga_models/analog_core/phase_interpolator.sv
@@ -4,8 +4,7 @@ module phase_interpolator #(
     parameter Nbit = 9,
     parameter Nctl_dcdl = 2,
     parameter Nunit = 32,
-    parameter Nblender = 4,
-    parameter [31:0] jitter_seed=46428 // emulation parameter
+    parameter Nblender = 4
 )(
     input rstb,
     input clk_in,
@@ -59,8 +58,7 @@ module phase_interpolator #(
         `PASS_REAL(emu_dt, emu_dt),
         `PASS_REAL(dt_req, dt_req),
         `PASS_REAL(dt_req_max, dt_req_max),
-        `PASS_REAL(jitter_rms, jitter_rms),
-        .jitter_seed(jitter_seed)
+        `PASS_REAL(jitter_rms, jitter_rms)
     ) clk_delay_core_i (
         // main I/O: delay code, clock in/out values
         .code(ctl),

--- a/vlog/fpga_models/analog_core/stochastic_adc_PR.sv
+++ b/vlog/fpga_models/analog_core/stochastic_adc_PR.sv
@@ -5,8 +5,7 @@ module stochastic_adc_PR #(
     parameter Nctl_TDC = 5,
     parameter Ndiv = 2,
     parameter Nctl_dcdl_fine = 2,
-    parameter Nadc = 8,
-    parameter [31:0] noise_seed=8518 // emulation parameter
+    parameter Nadc = 8
 )(
     input clk_in,
     input `pwl_t VinN,
@@ -118,8 +117,7 @@ module stochastic_adc_PR #(
     logic signed [8:0] adc_out;
     rx_adc_core #(
         `PASS_REAL(in_, VinP),
-        `PASS_REAL(noise_rms, noise_rms),
-        .noise_seed(noise_seed)
+        `PASS_REAL(noise_rms, noise_rms)
     ) rx_adc_core_i (
         // main I/O: input, output, and clock
         .in_(VinP),

--- a/vlog/fpga_models/analog_core/stochastic_adc_PR.sv
+++ b/vlog/fpga_models/analog_core/stochastic_adc_PR.sv
@@ -5,7 +5,8 @@ module stochastic_adc_PR #(
     parameter Nctl_TDC = 5,
     parameter Ndiv = 2,
     parameter Nctl_dcdl_fine = 2,
-    parameter Nadc = 8
+    parameter Nadc = 8,
+    parameter [31:0] noise_seed=8518 // emulation parameter
 )(
     input clk_in,
     input `pwl_t VinN,
@@ -42,6 +43,14 @@ module stochastic_adc_PR #(
 
     (* dont_touch = "true" *) logic emu_rst;
     (* dont_touch = "true" *) logic emu_clk;
+    (* dont_touch = "true" *) logic [10:0] noise_rms_int;
+
+    //////////////////////////////////
+    // convert noise to svreal type //
+    //////////////////////////////////
+
+    `INT_TO_REAL({1'b0, noise_rms_int}, 12, noise_rms_real);
+    `MUL_CONST_REAL(0.1e-3, noise_rms_real, noise_rms);
 
     ///////////////////////////
     // clk_in edge detection //
@@ -108,13 +117,19 @@ module stochastic_adc_PR #(
 
     logic signed [8:0] adc_out;
     rx_adc_core #(
-        `PASS_REAL(in_, VinP)
+        `PASS_REAL(in_, VinP),
+        `PASS_REAL(noise_rms, noise_rms),
+        .noise_seed(noise_seed)
     ) rx_adc_core_i (
         // main I/O: input, output, and clock
         .in_(VinP),
         .out_mag(adder_out),
         .out_sgn(sign_out),
         .clk_val(clk_adder),
+
+        // noise control
+        .noise_rms(noise_rms),
+
         // emulator clock and reset
         .emu_clk(emu_clk),
         .emu_rst(emu_rst)

--- a/vlog/fpga_models/analog_core/stochastic_adc_PR.sv
+++ b/vlog/fpga_models/analog_core/stochastic_adc_PR.sv
@@ -42,14 +42,7 @@ module stochastic_adc_PR #(
 
     (* dont_touch = "true" *) logic emu_rst;
     (* dont_touch = "true" *) logic emu_clk;
-    (* dont_touch = "true" *) logic [10:0] noise_rms_int;
-
-    //////////////////////////////////
-    // convert noise to svreal type //
-    //////////////////////////////////
-
-    `INT_TO_REAL({1'b0, noise_rms_int}, 12, noise_rms_real);
-    `MUL_CONST_REAL(0.1e-3, noise_rms_real, noise_rms);
+    (* dont_touch = "true" *) `MAKE_REAL(noise_rms, 250e-3);
 
     ///////////////////////////
     // clk_in edge detection //


### PR DESCRIPTION
## Summary
This PR adds noise and jitter to both the high-level and low-level emulator implementations, as well as to the CPU-based models used for throughput comparison.  This demonstrates new pseudorandom number generation (PRNG) features added to **msdsl** that enable us to emulate random effects with a few lines of code, like this:
https://github.com/StanfordVLSI/dragonphy2/blob/3b3c1c583008ae6fdab49414a400f34b34f8291c/dragonphy/fpga_models/rx_adc_core.py#L49-L52
The user can adjust the standard deviations of these noise sources using Python-based commands; there is no need to rebuild the bitstream.

## Key Files
Although there are ~1k lines of code in this PR, a lot of that is coming from updates to the testing infrastructure to verify the new features.  The features themselves are implemented in three **msdsl** models, and the changes to those models are relatively small:
1. ``dragonphy/fpga_models/analog_slice.py``: High-level model that combines ADC+PI behaviors and therefore includes both a jitter source and a voltage noise source.
2. ``dragonphy/fpga_models/clk_delay_core.py``: Digitally-control delay used in low-level PI model.  Jitter is added here.
3. ``dragonphy/fpga_models/rx_adc_core.py``: Used in the low-level ADC model; noise is added here.

## Other Comments
1. FPGA-based CI testing now uses a smaller channel model so that the resource utilization is not so close to the limits of the ZC702 board.  My experiments are still run on the larger ZC706 board using the full channel model.
2. Added ``pytest`` options ``--jitter_rms``, ``--noise_rms``, and ``--flatten_hierarchy``.  The first two are the standard deviations of noise sources while the last one is a debugging feature; occasionally it is useful to set ``--flatten_hierarchy`` to ``none`` when investigating synthesis issues.
3. The low-level emulator previously used a 32-bit fixed-point format for analog signals; this has been reduced to ``25`` to fit better within available FPGA resources (particularly for the ZC702 board used in CI testing).  The key change needed to support this was reducing the width of timestep requests from ``32`` to ``25``; this is OK because the exponent used for timestep requests is still ``-46``.  In other words, we kept 0.01ps resolution but reduced the maximum timestep from 30us to 200ns.  In our system, timesteps are usually 1ns or smaller, so this poses no problem.  As a side note, the reason ``25`` works so well is that our FPGA DSP blocks have ``25x18`` multipliers; constants are typically represented using ``18`` bit values, so dropping down to 25-bit signals provided a 2-3x reduction in DSP-related resource utilization.  (The high-level emulator is already using 25-bit fixed-point values)
4. ``tests/fpga_system_tests/emu/tb.sv`` (low-level emulator) has two somewhat messy additions, due to Vivado limitations:
    1. ``defparam`` is used to set unique seeds for PRNGs, since that would otherwise not be possible without modifying the real ``analog_core.sv`` code used in synthesizing the chip.  Unfortunately, ``defparam`` doesn't seem to work properly in a ``generate`` loop, so the ``defparams`` had to be unrolled.  Also note that functions like ``$urandom`` are not synthesizable, so the seed values have to be explicitly provided.
    2. The signals controlling standard deviation of noise and jitter have to be wired down into individual ADC and PI slices.  Unfortunately, due to a different ``generate`` loop synthesis bug, these ``assign`` statements had to be unrolled.