### PR TITLE
Add runtime-updatable step response functions

### DIFF
--- a/config/fpga/analog_slice_cfg.yml
+++ b/config/fpga/analog_slice_cfg.yml
@@ -1,6 +1,9 @@
 dt: 0.1e-6
 func_order: 1
 func_numel: 512
+func_domain: [0.0, 3.19375e-9]
+func_widths: [18, 18]
+func_exps: [-16, -16]
 chunk_width: 8
 num_chunks: 4
 slices_per_bank: 4

--- a/config/fpga/chan.yml
+++ b/config/fpga/chan.yml
@@ -1,4 +1,7 @@
 dt: 0.1e-6
 func_order: 1
 func_numel: 512
+func_domain: [0.0, 3.19375e-9]
+func_widths: [18, 18]
+func_exps: [-16, -16]
 num_terms: 25

--- a/conftest.py
+++ b/conftest.py
@@ -45,6 +45,14 @@ def pytest_addoption(parser):
         '--flatten_hierarchy', default='rebuilt', type=str, help='Vivado synthesis option.'
     )
 
+    parser.addoption(
+        '--chan_tau', default=25e-12, type=float, help='Time constant of channel used in emulation (seconds).'
+    )
+
+    parser.addoption(
+        '--chan_delay', default=31.25e-12, type=float, help='Delay of channel used in emulation (seconds).'
+    )
+
 @pytest.fixture
 def dump_waveforms(request):
     return request.config.getoption('--dump_waveforms')
@@ -88,3 +96,11 @@ def noise_rms(request):
 @pytest.fixture
 def flatten_hierarchy(request):
     return request.config.getoption('--flatten_hierarchy')
+
+@pytest.fixture
+def chan_tau(request):
+    return request.config.getoption('--chan_tau')
+
+@pytest.fixture
+def chan_delay(request):
+    return request.config.getoption('--chan_delay')

--- a/dragonphy/fpga_models/chan_core.py
+++ b/dragonphy/fpga_models/chan_core.py
@@ -6,6 +6,7 @@ import numpy as np
 from msdsl import MixedSignalModel, VerilogGenerator, sum_op
 from msdsl.expr.signals import AnalogState
 from msdsl.expr.extras import if_
+from msdsl.function import PlaceholderFunction
 
 # DragonPHY imports
 from dragonphy import Filter, get_file
@@ -30,16 +31,27 @@ class ChannelCore:
         m.add_digital_input('cke')
         m.add_digital_input('rst')
 
-        view = system_values['view']
+        # Create "placeholder function" that can be updated
+        # at runtime with the channel function
+        chan_func = PlaceholderFunction(
+                domain=system_values['func_domain'],
+                order=system_values['func_order'],
+                numel=system_values['func_numel'],
+                coeff_widths=system_values['func_widths'],
+                coeff_exps=system_values['func_exps']
+        )
 
-        # read in the channel data
+        # Check the function on a representative test case
         chan = Filter.from_file(get_file('build/chip_src/adapt_fir/chan.npy'))
+        self.check_func_error(chan_func, chan.interp)
 
-        # create a function
-        domain = [chan.t_vec[0], chan.t_vec[-1]]
-        chan_func = m.make_function(chan.interp, domain=domain, order=system_values['func_order'],
-                                    numel=system_values['func_numel'])
-        self.check_func_error(chan_func)
+        # Add digital inputs that will be used to reconfigure
+        # the function at runtime
+        wdata = []
+        for k in range(chan_func.order+1):
+            wdata += [m.add_digital_input(f'wdata{k}', signed=True, width=chan_func.coeff_widths[k])]
+        waddr = m.add_digital_input('waddr', width=chan_func.addr_bits)
+        we = m.add_digital_input('we')
 
         # create a history of past inputs
         cke_d = m.add_digital_state('cke_d')
@@ -74,7 +86,8 @@ class ChannelCore:
         # evaluate step response function
         step = []
         for k in range(system_values['num_terms']):
-            step_sig = m.set_from_sync_func(f'step_{k}', chan_func, time_mux[k+1], clk=m.clk, rst=m.rst)
+            step_sig = m.set_from_sync_func(f'step_{k}', chan_func, time_mux[k+1], clk=m.clk, rst=m.rst,
+                                            wdata=wdata, waddr=waddr, we=we)
             step.append(step_sig)
 
         # compute the products to be summed
@@ -95,14 +108,30 @@ class ChannelCore:
         self.generated_files = [filename]
 
     @staticmethod
-    def check_func_error(f):
-        samp = np.random.uniform(f.domain[0], f.domain[1], 1000)
-        approx = f.eval_on(samp)
-        exact = f.func(samp)
-        err = np.sqrt(np.mean((exact-approx)**2))
-        print(f'RMS error: {err}')
+    def check_func_error(placeholder, func):
+        # calculate coeffients
+        coeffs = placeholder.get_coeffs(func)
+
+        # determine test points
+        samp = np.random.uniform(placeholder.domain[0],
+                                 placeholder.domain[1],
+                                 1000)
+
+        # evaluate the function at those test points using
+        # the calculated coefficients
+        approx = placeholder.eval_on(samp, coeffs)
+
+        # determine the values the function should have at
+        # the test points
+        exact = func(samp)
+
+        # calculate the error
+        err = np.max(np.abs(exact-approx))
+
+        # display the error
+        print(f'Worst-case error: {err}')
 
     @staticmethod
     def required_values():
-        return ['dt', 'func_order', 'func_numel', 'num_terms']
-
+        return ['dt', 'func_order', 'func_numel', 'num_terms',
+                'func_domain', 'func_widths', 'func_exps']

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -255,3 +255,25 @@ July 21, 2020
   * Build time: 47m40.715s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
   * Maximum time constant: 217ps (--chan_tau=217e-12)
+
+July 23, 2020
+* Second experiment with updatable functions, this time run on the "low-level" model.  A PWL representation was used for functions, with width=18 and exponent=-16 for both the offset and slope values (representing about +/-2 for each).  Run on ZC706.
+  * command: ``time pytest tests/fpga_system_tests/emu/test_emu.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB1 --ffe_length 10 --emu_clk_freq 20e6 --prbs_test_dur 1``
+  * PRBS test took 30.0692880153656 seconds.
+  * Total bits: 150234304
+  * 4.996 Mb/s
+  * Slice LUTs: 60655 / 218600
+    * analog_core: 6405
+    * digital_core: 40044
+  * Slice Registers: 24311 / 437200
+    * analog_core: 1191
+    * digital_core: 17813
+  * Slice: 19882 / 54650
+    * analog_core: 2106 
+    * digital_core: 14249
+  * DSP: 187 / 900
+  * BRAM: 73.5 / 545
+    * exactly 25 for the channel model (i.e., number of taps).  this is the only delta in BRAM usage from the previous fixed-function version, so this is all as expected.
+  * Build time:  31m3.938s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * Maximum time constant: 217ps (--chan_tau=217e-12)

--- a/experiments/cpu_emu_comparison/results.md
+++ b/experiments/cpu_emu_comparison/results.md
@@ -231,3 +231,27 @@ July 19, 2020
     * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
   * Max noise code: "560" (--noise_rms 56e-3)
   * Max jitter code: "26" (--jitter_rms 2.6e-12)
+
+July 21, 2020
+* First experiment with updatable functions, run on the "high-level" model.  A PWL representation was used for functions, with width=18 and exponent=-16 for both the offset and slope values (representing about +/-2 for each).  Run on ZC706.
+  * command: ``time pytest tests/fpga_system_tests/emu_macro/test_emu_macro.py::test_3 -s --board_name ZC706 --ser_port /dev/ttyUSB0 --ffe_length 10 --emu_clk_freq 30e6 --prbs_test_dur 1``
+  * PRBS test took 30.06890892982483 seconds.
+  * Total bits: 2403924544
+  * 79.95 Mb/s
+  * Slice LUTs: 85102 / 218600
+    * analog_core: 29028
+    * digital_core: 40163
+  * Slice Registers: 23828 / 437200
+    * analog_core: 1596
+    * digital_core: 17797
+  * Slice: 27902 / 54650
+    * analog_core: 9837
+    * digital_core: 15254
+  * DSP: 850 / 900
+    * 53 per slice
+  * BRAM: 194.5 / 545
+    * 9.5 per slice (16x), 32 in digital core and 10.5 from debug core
+    * sync_rams are all using 1/2 slice as expected
+  * Build time: 47m40.715s with Vivado 2020.1 on Intel(R) Core(TM) i5-2320 CPU @ 3.00GHz, Ubuntu 18.04.2 LTS, 6 GB RAM
+    * use `cat /proc/cpuinfo`, `cat /proc/meminfo`, `lsb_release -a`
+  * Maximum time constant: 217ps (--chan_tau=217e-12)

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open('README.md', 'r') as fh:
 
 requires_list = [
     # anasymod ecosystem
-    'svreal==0.2.2',
-    'msdsl==0.3.0',
+    'svreal==0.2.4',
+    'msdsl==0.3.1',
     'anasymod==0.3.2',
     # system-verilog parser
     'svinst==0.1.5',

--- a/tests/fpga_block_tests/analog_core/test_analog_core.sv
+++ b/tests/fpga_block_tests/analog_core/test_analog_core.sv
@@ -36,7 +36,13 @@ module test_analog_core import const_pack::*; #(
 
     // Jitter/Noise commands
     input [6:0] jitter_rms_int,
-    input [10:0] noise_rms_int
+    input [10:0] noise_rms_int,
+
+    // Step response control signals
+    input [17:0] chan_wdata_0,
+    input [17:0] chan_wdata_1,
+    input [8:0] chan_waddr,
+    input chan_we
 );
     // wire ctl_pi
     logic [Npi-1:0] ctl_pi [Nout-1:0];
@@ -98,6 +104,10 @@ module test_analog_core import const_pack::*; #(
     assign analog_core_i.emu_rst = rst;
     assign analog_core_i.jitter_rms_int = jitter_rms_int;
     assign analog_core_i.noise_rms_int = noise_rms_int;
+    assign analog_core_i.chan_wdata_0 = chan_wdata_0;
+    assign analog_core_i.chan_wdata_1 = chan_wdata_1;
+    assign analog_core_i.chan_waddr = chan_waddr;
+    assign analog_core_i.chan_we = chan_we;
 
     // waveform dumping
     initial begin

--- a/tests/fpga_block_tests/analog_slice/test_analog_slice.sv
+++ b/tests/fpga_block_tests/analog_slice/test_analog_slice.sv
@@ -19,7 +19,11 @@ module test_analog_slice #(
     input wire logic clk,
     input wire logic rst,
     input real jitter_rms,
-    input real noise_rms
+    input real noise_rms,
+    input wire logic [17:0] wdata0,
+    input wire logic [17:0] wdata1,
+    input wire logic [8:0] waddr,
+    input wire logic we
 );
     // declare svreal types for jitter and noise
     `MAKE_REAL(jitter_rms_int, 10e-12);
@@ -46,6 +50,11 @@ module test_analog_slice #(
         .clk(clk),
         .rst(rst),
         .jitter_rms(jitter_rms_int),
-        .noise_rms(noise_rms_int)
+        .noise_rms(noise_rms_int),
+        // runtime-defined function controls
+        .wdata0(wdata0),
+        .wdata1(wdata1),
+        .waddr(waddr),
+        .we(we)
     );
 endmodule

--- a/tests/fpga_block_tests/chan_model/test_chan_model.py
+++ b/tests/fpga_block_tests/chan_model/test_chan_model.py
@@ -167,7 +167,7 @@ def test_chan_model(simulator_name):
     # define parameters
     parameters = {
         'width0': CFG['func_widths'][0],
-        'wdata1': CFG['func_widths'][1],
+        'width1': CFG['func_widths'][1],
         'naddr': int(ceil(log2(CFG['func_numel'])))
     }
 
@@ -182,7 +182,9 @@ def test_chan_model(simulator_name):
         ext_model_file=True,
         disp_type='realtime',
         parameters=parameters,
-        dump_waveforms=False
+        dump_waveforms=False,
+        timescale='1ns/1ps', 
+		num_cycles=1e12
     )
 
     # check outputs

--- a/tests/fpga_block_tests/chan_model/test_chan_model.sv
+++ b/tests/fpga_block_tests/chan_model/test_chan_model.sv
@@ -1,12 +1,20 @@
 `include "svreal.sv"
 
-module test_chan_model (
+module test_chan_model #(
+    parameter integer width0=18,
+    parameter integer width1=18,
+    parameter integer naddr=9
+) (
     input real in_,
     output real out,
     input real dt_sig,
     input clk,
     input cke,
-    input rst
+    input rst,
+    input [(width0-1):0] wdata0,
+    input [(width1-1):0] wdata1,
+    input [(naddr-1):0] waddr,
+    input we
 );
     // wire input
     `REAL_FROM_WIDTH_EXP(in_int, 18, -12);
@@ -31,6 +39,11 @@ module test_chan_model (
         .dt_sig(dt_int),
         .clk(clk),
         .cke(cke),
-        .rst(rst)
+        .rst(rst),
+        // runtime-defined function controls
+        .wdata0(wdata0),
+        .wdata1(wdata1),
+        .waddr(waddr),
+        .we(we)
     );
 endmodule

--- a/tests/fpga_system_tests/emu/main.c
+++ b/tests/fpga_system_tests/emu/main.c
@@ -255,7 +255,7 @@ int main() {
                         nargs++;
                     } else {
 	                xil_printf("ERROR: Unknown command\r\n");
-		            }
+                    }
                 } else if (nargs == 1) {
                     sscanf(buf, "%lu", &arg1);
                     if (cmd == SET_RSTB) {
@@ -280,12 +280,15 @@ int main() {
                     sscanf(buf, "%lu", &arg2);
                     if (cmd == SIR) {
                         shift_ir(arg1, arg2);
+			nargs=0;
                     } else if (cmd == SDR) {
                         xil_printf("%lu\r\n", shift_dr(arg1, arg2));
+			nargs=0;
                     } else if (cmd == QSDR) {
                         shift_dr(arg1, arg2);
+			nargs=0;
                     } else {
-                        nargs++
+                        nargs++;
                     }
                 } else if (nargs > 2) {
                     sscanf(buf, "%lu", &argn);

--- a/tests/fpga_system_tests/emu/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu/sim_ctrl.sv
@@ -16,6 +16,10 @@ module sim_ctrl(
     output reg dump_start=1'b0,
     output reg [6:0] jitter_rms_int,
     output reg [10:0] noise_rms_int,
+    output reg [17:0] chan_wdata_0,
+    output reg [17:0] chan_wdata_1,
+    output reg [8:0] chan_waddr,
+    output reg chan_we,
     input wire tdo
 );
 	import const_pack::*;
@@ -24,6 +28,11 @@ module sim_ctrl(
     import ffe_gpack::length;
     import ffe_gpack::weight_precision;
     import constant_gpack::channel_width;
+
+    // function parameters
+    localparam real dt_samp=1.0/(160.0e9);
+    localparam integer numel=512;
+    localparam real chan_delay=31.25e-12;
 
     // calculate FFE coefficients
     localparam real dt=1.0/(16.0e9);
@@ -55,14 +64,36 @@ module sim_ctrl(
         #((200.0/(`EMU_CLK_FREQ))*1s);
     endtask
 
+    function real chan_func(input real t);
+        if (t <= chan_delay) begin
+            chan_func = 0.0;
+        end else begin
+            chan_func = 1.0-$exp(-(t-chan_delay)/tau);
+        end
+    endfunction
+
     initial begin
         // TODO: explore jitter/noise effect
         jitter_rms_int = 0;
         noise_rms_int = 0;
+        chan_wdata_0 = 0;
+        chan_wdata_1 = 0;
+        chan_waddr = 0;
+        chan_we = 0;
 
         // wait for emulator reset to complete
         $display("Waiting for emulator reset to complete...");
         #((50.0/(`EMU_CLK_FREQ))*1s);
+
+        // update the step response function
+        chan_we = 1'b1;
+        for (int idx=0; idx<512; idx=idx+1) begin
+            chan_wdata_0 = chan_func(idx*dt_samp)*(2.0**16);
+            chan_wdata_1 = (chan_func((idx+1)*dt_samp)-chan_func(idx*dt_samp))*(2.0**16);
+            chan_waddr = idx;
+            #((1.1/(`EMU_CLK_FREQ))*1s);
+        end
+        chan_we = 1'b0;
 
         // release external reset signals
         rstb = 1'b1;

--- a/tests/fpga_system_tests/emu/simctrl.yaml
+++ b/tests/fpga_system_tests/emu/simctrl.yaml
@@ -31,6 +31,22 @@ digital_ctrl_inputs:
     abspath: 'tb_i.noise_rms_int'
     width: 11
     init_value: 0
+  chan_wdata_0:
+    abspath: 'tb_i.chan_wdata_0'
+    width: 18
+    init_value: 0
+  chan_wdata_1:
+    abspath: 'tb_i.chan_wdata_1'
+    width: 18
+    init_value: 0
+  chan_waddr:
+    abspath: 'tb_i.chan_waddr'
+    width: 9
+    init_value: 0
+  chan_we:
+    abspath: 'tb_i.chan_we'
+    width: 1
+    init_value: 0
 digital_ctrl_outputs:
   tdo:
     abspath: 'tb_i.tdo'

--- a/tests/fpga_system_tests/emu/tb.sv
+++ b/tests/fpga_system_tests/emu/tb.sv
@@ -35,6 +35,10 @@ module tb;
     (* dont_touch = "true" *) `DECL_DT(dt_req);
     (* dont_touch = "true" *) logic [6:0] jitter_rms_int;
     (* dont_touch = "true" *) logic [10:0] noise_rms_int;
+    (* dont_touch = "true" *) logic [17:0] chan_wdata_0;
+    (* dont_touch = "true" *) logic [17:0] chan_wdata_1;
+    (* dont_touch = "true" *) logic [8:0] chan_waddr;
+    (* dont_touch = "true" *) logic chan_we;
 
     //////////////
     // TX clock //
@@ -103,7 +107,12 @@ module tb;
         .dt_sig(emu_dt),
         .clk(emu_clk),
         .rst(emu_rst),
-        .cke(clk_tx_val_posedge)
+        .cke(clk_tx_val_posedge),
+        // runtime-defined function controls
+        .wdata0(chan_wdata_0),
+        .wdata1(chan_wdata_1),
+        .waddr(chan_waddr),
+        .we(chan_we)
     );
 
     ///////////////////

--- a/tests/fpga_system_tests/emu/test_emu.py
+++ b/tests/fpga_system_tests/emu/test_emu.py
@@ -3,14 +3,18 @@ import serial
 import time
 import json
 import re
+import yaml
+import numpy as np
 from pathlib import Path
 from math import exp, ceil, log2
 
 from anasymod.analysis import Analysis
+from msdsl.function import PlaceholderFunction
 from dragonphy import *
 from dragonphy.git_util import get_git_hash_short
 
 THIS_DIR = Path(__file__).resolve().parent
+CFG = yaml.load(open(get_file('config/fpga/chan.yml'), 'r'))
 
 def test_1(board_name, emu_clk_freq, flatten_hierarchy):
     # Write project config
@@ -83,7 +87,7 @@ def test_5():
     ana.set_target(target_name='fpga')
     ana.program_firmware()
 
-def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_rms):
+def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_rms, chan_tau, chan_delay):
     jtag_inst_width = 5
     sc_bus_width = 32
     sc_addr_width = 14
@@ -228,6 +232,17 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_
         write_tc_reg('wme_ffe_exec', 1)
         write_tc_reg('wme_ffe_exec', 0)
 
+    def update_chan(coeff_tuples, offset=0):
+        # put together the command
+        args = ['UPDATE_CHAN', offset, len(coeff_tuples)]
+        for coeff_tuple in coeff_tuples:
+            args += coeff_tuple
+        cmd = ' '.join(str(elem) for elem in args)
+        ser.write((cmd + '\n').encode('utf-8'))
+
+        # stall until confirmation is received
+        assert ser.readline().decode('utf-8').strip() == 'OK', 'Serial error'
+
     # Initialize
     jtag_sleep_us = int(ceil((110/emu_clk_freq)*1e6))
     set_sleep(jtag_sleep_us)
@@ -247,6 +262,18 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_
     # Configure noise
     set_jitter_rms(int(round(jitter_rms*1e13)))
     set_noise_rms(int(round(noise_rms*1e4)))
+
+    # Configure step response function
+    placeholder = PlaceholderFunction(domain=CFG['func_domain'], order=CFG['func_order'],
+                                      numel=CFG['func_numel'], coeff_widths=CFG['func_widths'],
+                                      coeff_exps=CFG['func_exps'])
+    chan_func = lambda t_vec: (1-np.exp(-(t_vec-chan_delay)/chan_tau))*np.heaviside(t_vec-chan_delay, 0)
+    coeffs_bin = placeholder.get_coeffs_bin_fmt(chan_func)
+    coeff_tuples = list(zip(*coeffs_bin))
+    chunk_size = 32
+    for k in range(len(coeff_tuples)//chunk_size):
+        print(f'Updating channel at chunk {k}...')
+        update_chan(coeff_tuples[(k*chunk_size):((k+1)*chunk_size)], offset=k*chunk_size)
 
     # Soft reset
     print('Soft reset')
@@ -276,9 +303,8 @@ def test_6(ser_port, ffe_length, emu_clk_freq, prbs_test_dur, jitter_rms, noise_
 
     # Set up the FFE
     dt=1.0/(16.0e9)
-    tau=25.0e-12
-    coeff0 = 128.0/(1.0-exp(-dt/tau))
-    coeff1 = -128.0*exp(-dt/tau)/(1.0-exp(-dt/tau))
+    coeff0 = 128.0/(1.0-exp(-dt/chan_tau))
+    coeff1 = -128.0*exp(-dt/chan_tau)/(1.0-exp(-dt/chan_tau))
     for loop_var in range(16):
         for loop_var2 in range(ffe_length):
             if (loop_var2 == 0):

--- a/tests/fpga_system_tests/emu_macro/main.c
+++ b/tests/fpga_system_tests/emu_macro/main.c
@@ -342,9 +342,9 @@ int main() {
 
                             // check if that was the last update
                             if (nargs == (2 + arg2*2)) {
+                                xil_printf("OK\r\n");
                                 nargs = 0;
                             } else {
-                                xil_printf("OK\r\n");
                                 nargs++;
                             }
                         }

--- a/tests/fpga_system_tests/emu_macro/main.c
+++ b/tests/fpga_system_tests/emu_macro/main.c
@@ -25,6 +25,12 @@ void do_init() {
    set_jitter_rms_int(0);
    set_noise_rms_int(0);
 
+   // step response function
+   set_chan_wdata_0(0);
+   set_chan_wdata_1(0);
+   set_chan_waddr(0);
+   set_chan_we(0);
+
    // JTAG-specific
    set_tdi(0);
    set_tck(0);
@@ -143,6 +149,20 @@ u32 read_id() {
     return shift_dr(0, 32);
 }
 
+void write_chan_data(u32 chan_index, u32 chan_data_0, u32 chan_data_1) {
+    // update write data and address
+    set_chan_wdata_0(chan_data_0);
+    set_chan_wdata_1(chan_data_1);
+    set_chan_waddr(chan_index);
+
+    // pulse "write enable" high
+    usleep(1);
+    set_chan_we(1);
+    usleep(1);
+    set_chan_we(0);
+    usleep(1);
+}
+
 enum cmd_t {
     RESET,
     INIT,
@@ -160,7 +180,8 @@ enum cmd_t {
     SET_TRST_N,
     GET_TDO,
     SET_NOISE_RMS,
-    SET_JITTER_RMS
+    SET_JITTER_RMS,
+    UPDATE_CHAN
 } cmd;
 
 int main() {
@@ -172,7 +193,13 @@ int main() {
     // command processing;
     u32 arg1;
     u32 arg2;
+    u32 argn;
     u32 nargs = 0;
+
+    // channel update variables
+    u32 chan_index;
+    u32 chan_data_0;
+    u32 chan_data_1;
 
     if (init_GPIO() != 0) {
         xil_printf("GPIO Initialization Failed\r\n");
@@ -240,6 +267,9 @@ int main() {
                     } else if (strcmp(buf, "SET_JITTER_RMS") == 0) {
                         cmd = SET_JITTER_RMS;
                         nargs++;
+                    } else if (strcmp(buf, "UPDATE_CHAN") == 0) {
+                        cmd = UPDATE_CHAN;
+                        nargs++;
                     } else if (strcmp(buf, "GET_TDO") == 0) {
                         cmd = GET_TDO;
                         xil_printf("%lu\r\n", get_tdo());
@@ -283,13 +313,45 @@ int main() {
                     sscanf(buf, "%lu", &arg2);
                     if (cmd == SIR) {
                         shift_ir(arg1, arg2);
+                        nargs = 0;
                     } else if (cmd == SDR) {
                         xil_printf("%lu\r\n", shift_dr(arg1, arg2));
+                        nargs = 0;
                     } else if (cmd == QSDR) {
                         shift_dr(arg1, arg2);
+                        nargs = 0;
+                    } else {
+                        nargs++;
                     }
-                    nargs = 0;
-                }  
+                } else if (nargs > 2) {
+                    sscanf(buf, "%lu", &argn);
+                    if (cmd == UPDATE_CHAN) {
+                        if (nargs % 2 == 1) {
+                            // assign data to order "0"
+                            chan_data_0 = argn;
+
+                            // increment argument counter
+                            nargs++;
+                        } else {
+                            // assign data to order "1"
+                            chan_data_1 = argn;
+
+                            // write data to the correct index
+                            chan_index = arg1 + ((nargs-4)/2);
+                            write_chan_data(chan_index, chan_data_0, chan_data_1);
+
+                            // check if that was the last update
+                            if (nargs == (2 + arg2*2)) {
+                                nargs = 0;
+                            } else {
+                                xil_printf("OK\r\n");
+                                nargs++;
+                            }
+                        }
+                    } else {
+                        nargs++;
+                    }
+                }
             }
             idx = 0;
         } else {

--- a/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
@@ -19,7 +19,7 @@ module sim_ctrl(
     output reg [17:0] chan_wdata_0,
     output reg [17:0] chan_wdata_1,
     output reg [8:0] chan_waddr,
-    output reg chan_we
+    output reg chan_we,
     input wire tdo
 );
 	import const_pack::*;
@@ -32,6 +32,7 @@ module sim_ctrl(
     // function parameters
     localparam real dt_samp=1.0/(160.0e9);
     localparam integer numel=512;
+    localparam real chan_delay=31.25e-12;
 
     // calculate FFE coefficients
     localparam real dt=1.0/(16.0e9);
@@ -64,6 +65,14 @@ module sim_ctrl(
         #((10.0/(`EMU_CLK_FREQ))*1s);
     endtask
 
+    function real chan_func(input real t);
+        if (t <= chan_delay) begin
+            chan_func = 0.0;
+        end else begin
+            chan_func = 1.0-$exp(-(t-chan_delay)/tau);
+        end
+    endfunction
+
     initial begin
         // initialize control signals
         jitter_rms_int = 0;
@@ -76,6 +85,16 @@ module sim_ctrl(
         // wait for emulator reset to complete
         $display("Waiting for emulator reset to complete...");
         #((10.0/(`EMU_CLK_FREQ))*1s);
+
+        // update the step response function
+        chan_we = 1'b1;
+        for (int idx=0; idx<512; idx=idx+1) begin
+            chan_wdata_0 = chan_func(idx*dt_samp)*(2.0**16); 
+            chan_wdata_1 = (chan_func((idx+1)*dt_samp)-chan_func(idx*dt_samp))*(2.0**16); 
+            chan_waddr = idx;
+            #((1.1/(`EMU_CLK_FREQ))*1s);
+        end
+        chan_we = 1'b0;
 
         // release external reset signals
         rstb = 1'b1;

--- a/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
+++ b/tests/fpga_system_tests/emu_macro/sim_ctrl.sv
@@ -16,6 +16,10 @@ module sim_ctrl(
     output reg dump_start=1'b0,
     output reg [6:0] jitter_rms_int,
     output reg [10:0] noise_rms_int,
+    output reg [17:0] chan_wdata_0,
+    output reg [17:0] chan_wdata_1,
+    output reg [8:0] chan_waddr,
+    output reg chan_we
     input wire tdo
 );
 	import const_pack::*;
@@ -24,6 +28,10 @@ module sim_ctrl(
     import ffe_gpack::length;
     import ffe_gpack::weight_precision;
     import constant_gpack::channel_width;
+
+    // function parameters
+    localparam real dt_samp=1.0/(160.0e9);
+    localparam integer numel=512;
 
     // calculate FFE coefficients
     localparam real dt=1.0/(16.0e9);
@@ -35,7 +43,8 @@ module sim_ctrl(
     logic [Npi-1:0] tmp_ext_pi_ctl_offset [Nout-1:0];
 
     integer loop_var, loop_var2;
-    longint err_bits, total_bits;
+    logic [63:0] err_bits;
+    logic [63:0] total_bits;
 
     logic [ffe_gpack::shift_precision-1:0] tmp_ffe_shift [constant_gpack::channel_width-1:0];
 
@@ -56,9 +65,13 @@ module sim_ctrl(
     endtask
 
     initial begin
-        // TODO: explore jitter/noise effect
+        // initialize control signals
         jitter_rms_int = 0;
         noise_rms_int = 0;
+        chan_wdata_0 = 0;
+        chan_wdata_1 = 0;
+        chan_waddr = 0;
+        chan_we = 0;
 
         // wait for emulator reset to complete
         $display("Waiting for emulator reset to complete...");
@@ -191,16 +204,16 @@ module sim_ctrl(
 
         // Check results
 
-        if (!(total_bits >= 500)) begin
-            $error("Not enough bits transmitted");
-        end else begin
+        if (total_bits >= 500) begin
             $display("Number of bits transmitted is OK");
+        end else begin
+            $error("Not enough bits transmitted");
         end
 
-        if (!(err_bits == 0)) begin
-            $error("Bit error detected");
-        end else begin
+        if (err_bits == 0) begin
             $display("No bit errors detected");
+        end else begin
+            $error("Bit error detected");
         end
 
 		// Finish test

--- a/tests/fpga_system_tests/emu_macro/simctrl.yaml
+++ b/tests/fpga_system_tests/emu_macro/simctrl.yaml
@@ -31,6 +31,22 @@ digital_ctrl_inputs:
     abspath: 'tb_i.top_i.iacore.noise_rms_int'
     width: 11
     init_value: 0
+  chan_wdata_0:
+    abspath: 'tb_i.top_i.iacore.chan_wdata_0'
+    width: 18
+    init_value: 0
+  chan_wdata_1:
+    abspath: 'tb_i.top_i.iacore.chan_wdata_1'
+    width: 18
+    init_value: 0
+  chan_waddr:
+    abspath: 'tb_i.top_i.iacore.chan_waddr'
+    width: 9
+    init_value: 0
+  chan_we:
+    abspath: 'tb_i.top_i.iacore.chan_we'
+    width: 1
+    init_value: 0
 digital_ctrl_outputs:
   tdo:
     abspath: 'tb_i.tdo'

--- a/tests/fpga_system_tests/emu_macro/simvision.svcf
+++ b/tests/fpga_system_tests/emu_macro/simvision.svcf
@@ -1,4 +1,4 @@
-# SimVision Command Script (Wed Jul 15 05:30:11 PM PDT 2020)
+# SimVision Command Script (Tue Jul 21 01:58:18 PM PDT 2020)
 #
 # Version 19.03.s003
 #
@@ -73,23 +73,29 @@ set id [waveform add -signals [subst  {
 	{$dbNames(realName1)::[format {top.trace_port_gen_i.ctl_pi_0[8:0]}]}
 	} ]]
 waveform format $id -radix %d -trace analogSampleAndHold
-waveform axis range $id -for default -min 0 -max 64 -scale linear
+waveform axis range $id -for default -min 0 -max 65 -scale linear
 set id [waveform add -signals [subst  {
 	{[format {signed(%s::top.trace_port_gen_i.adcout_unfolded_0)}  $dbNames(realName1)]}
 	} ]]
 waveform format $id -radix %d -trace analogSampleAndHold
-waveform axis range $id -for default -min -127 -max 127 -scale linear
+waveform axis range $id -for default -min -127 -max 126 -scale linear
 set id [waveform add -signals [subst  {
 	{[format {signed(%s::top.trace_port_gen_i.estimated_bits_0)}  $dbNames(realName1)]}
 	} ]]
 waveform format $id -radix %d -trace analogSampleAndHold
-waveform axis range $id -for default -min -127 -max 126 -scale linear
+waveform axis range $id -for default -min -127 -max 291 -scale linear
 
-waveform xview limits 1003999804688fs 1160499804688fs
+waveform xview limits 1091803118168fs 1418883118168fs
 
 #
 # Waveform Window Links
 #
+
+#
+# Console windows
+#
+console set -windowname Console
+window geometry Console 600x250+118+147
 
 #
 # Layout selection

--- a/vlog/fpga_models/analog_core/analog_core.sv
+++ b/vlog/fpga_models/analog_core/analog_core.sv
@@ -40,6 +40,10 @@ module analog_core import const_pack::*; #(
     (* dont_touch = "true" *) logic emu_rst;
     (* dont_touch = "true" *) logic [6:0] jitter_rms_int;
     (* dont_touch = "true" *) logic [10:0] noise_rms_int;
+    (* dont_touch = "true" *) logic [17:0] chan_wdata_0;
+    (* dont_touch = "true" *) logic [17:0] chan_wdata_1;
+    (* dont_touch = "true" *) logic [8:0] chan_waddr;
+    (* dont_touch = "true" *) logic chan_we;
 
     // convert noise / jitter to svreal types
 
@@ -86,7 +90,12 @@ module analog_core import const_pack::*; #(
                 .clk(emu_clk),
                 .rst(emu_rst),
                 .jitter_rms(jitter_rms),
-                .noise_rms(noise_rms)
+                .noise_rms(noise_rms),
+                // control signals to update step response
+                .wdata0(chan_wdata_0),
+                .wdata1(chan_wdata_1),
+                .waddr(chan_waddr),
+                .we(chan_we)
             );
         end
     endgenerate


### PR DESCRIPTION
## Summary
This PR leverages new features in ``msdsl`` and ``svreal`` to model channel dynamics in a way that can be updated at runtime, without requiring the bitstream to be rebuilt.  The feature has been added to both high-level and low-level emulator architectures.  Emulator throughput was not affected by this change, but it was interesting to note that BRAM utilization is up while LUT utilization is down.  This suggests that Vivado synthesis had been using LUTs to implement some synchronous ROMs in the previous implementations of channel dynamics.

Here's an example of what updating the step response function at runtime looks like from a user perspective:
```python
placeholder = PlaceholderFunction(...)  # defines fixed-point formatting of piecewise-polynomial coefficients
chan_func = ...  # can use a regular Python function here
coeffs_bin = placeholder.get_coeffs_bin_fmt(chan_func)
coeff_tuples = list(zip(*coeffs_bin))
update_chan(coeff_tuples)  # transmits coefficients to FPGA over USB-UART
```

## Details
* As usual, most of the changes in the PR are in the testing infrastructure; the updates to the models themselves (``analog_slice`` and ``chan_core``) are about 25 lines each.
* The updatable functions can be configured via ``config/fpga/analog_slice_cfg.yml`` (high-level architecture) and ``config/fpga/chan.yml`` (low-level architecture)
* New ``pytest`` options ``--chan_tau`` and ``--chan_delay`` allow the user to conveniently specify the time constant and delay for the channel, assuming an exponential step response.  However, the user can provide their own function if an exponential step response is not sufficient, without having to rebuild the bitstream.