### PR TITLE
Fix some block-level tests that were broken under irun/xrun

### DIFF
--- a/tests/cpu_block_tests/adc_unfolding/test_adc_unfolding.py
+++ b/tests/cpu_block_tests/adc_unfolding/test_adc_unfolding.py
@@ -124,7 +124,8 @@ def test_ext_offset(simulator_name, offset):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     ##################
@@ -232,7 +233,8 @@ def test_int_offset(simulator_name, offset, init):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     ##################

--- a/tests/cpu_block_tests/avg_pulse/test_avg_pulse.py
+++ b/tests/cpu_block_tests/avg_pulse/test_avg_pulse.py
@@ -69,7 +69,8 @@ def test_sim(simulator_name, ndiv, N=4, nper=5):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     ##################

--- a/tests/cpu_block_tests/calib_hist/test_calib_hist.py
+++ b/tests/cpu_block_tests/calib_hist/test_calib_hist.py
@@ -149,7 +149,8 @@ def test_sim(simulator_name, Nadc=8, Nrange=4, Navg=7,
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     ##################

--- a/tests/cpu_block_tests/data_gen_only/test_data_gen.py
+++ b/tests/cpu_block_tests/data_gen_only/test_data_gen.py
@@ -109,7 +109,8 @@ def test_sim(simulator_name, n=8):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     ###################

--- a/tests/cpu_block_tests/histogram_only/test_histogram_only.py
+++ b/tests/cpu_block_tests/histogram_only/test_histogram_only.py
@@ -98,7 +98,8 @@ def test_sim(simulator_name, n_data=8, n_count=64):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     # convert results

--- a/tests/cpu_block_tests/prbs_checker_core_only/test_prbs_checker_core.py
+++ b/tests/cpu_block_tests/prbs_checker_core_only/test_prbs_checker_core.py
@@ -110,7 +110,8 @@ def test_sim(simulator_name, n_prbs, n_channels=16, n_trials=256):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     # post-process results

--- a/tests/cpu_block_tests/prbs_checker_only/test_prbs_checker.py
+++ b/tests/cpu_block_tests/prbs_checker_only/test_prbs_checker.py
@@ -127,7 +127,8 @@ def test_sim(simulator_name, n_prbs, n_channels=16, n_trials=256):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     print(f'err_bits_case_1: {err_bits_case_1.value}')

--- a/tests/cpu_block_tests/prbs_generator_syn_only/test_prbs_generator_syn.py
+++ b/tests/cpu_block_tests/prbs_generator_syn_only/test_prbs_generator_syn.py
@@ -75,5 +75,6 @@ def test_sim(simulator_name):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=True,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )

--- a/tests/cpu_block_tests/sample_avg/test_sample_avg.py
+++ b/tests/cpu_block_tests/sample_avg/test_sample_avg.py
@@ -117,7 +117,8 @@ def test_sim(simulator_name, Nadc=8, Nrange=4, Navg=10):
         ext_model_file=True,
         disp_type='realtime',
         dump_waveforms=False,
-        directory=BUILD_DIR
+        directory=BUILD_DIR,
+        num_cycles=1e12
     )
 
     ##################


### PR DESCRIPTION
This small PR fixes a couple of tests that were failing when simulated with ``irun``/``xrun`` because the simulator was exiting early (had to do with the ``num_cycle`` argument not being set correctly in ``fault``).  We weren't seeing this on the regression servers because they use ``iverilog`` for those tests.