### PR TITLE
Remove misc_ctrl_bits register and move PRBS debug I/O to system clock

### DIFF
--- a/md/cdr_intf.md
+++ b/md/cdr_intf.md
@@ -14,4 +14,5 @@
 | sel_inp_mux    |           |                           |               | Test         | out      | 0         |
 | sample_state   |           |                           |               | Test         | out      | 0         |
 | invert         |           |                           |               | Test         | out      | 0         |
+| cdr_en_clamp   |           |                           |               | Test         | out      | 0         |
 | cdr_clamp_amt  | yes       | 31:0                      |               | Test         | out      | 1048576   |

--- a/md/dcore_intf.md
+++ b/md/dcore_intf.md
@@ -32,8 +32,8 @@
 | int_rstb                   |         |                        |                  | Test         | out      |   0       |
 | sram_rstb                  |         |                        |                  | Test         | out      |   1       |
 | cdr_rstb                   |         |                        |                  | Test         | out      |   1       |
-| prbs_rstb                  |         |                        |                  | Test         | out      |   0       |
-| prbs_gen_rstb              |         |                        |                  | Test         | out      |   0       |
+| prbs_rstb                  |         |                        |                  | System       | out      |   0       |
+| prbs_gen_rstb              |         |                        |                  | System       | out      |   0       |
 | sel_outbuff				 | 		   | 3:0					|				   | Test		  | out 	 |   0		 |
 | sel_trigbuff				 | 		   | 3:0					|				   | Test		  | out 	 |   0		 |
 | en_outbuff				 | 		   |     					|				   | Test		  | out 	 |   0		 |
@@ -48,7 +48,10 @@
 | disable_product            |         | Nti-1:0                | 9:0              | Test         | out      |   0       |
 | ffe_thresh                 |   yes   | 9:0                    | Nti-1:0          | Test         | out      |   0       |
 | adc_thresh                 |   yes   | 7:0                    | Nti-1:0          | Test         | out      |   0       |
-| sel_prbs_mux               |         | 1:0                    |                  | Test         | out      |   0       |
+| sel_prbs_mux               |         | 1:0                    |                  | System       | out      |   0       |
 | en_cgra_clk                |         |                        |                  | Test         | out      |   0       |
 | pfd_cal_ext_ave            | yes     | Nadc-1:0               |                  | Test         | out      |   0       |
-| misc_ctrl_bits             |         | 31:0                   |                  | Test         | out      |   0       |
+| pfd_cal_flip_feedback      |         |                        |                  | Test         | out      |   0       |
+| en_pfd_cal_ext_ave         |         |                        |                  | Test         | out      |   0       |
+| en_int_dump_start          |         |                        |                  | Test         | out      |   0       |
+| int_dump_start             |         |                        |                  | Test         | out      |   0       |

--- a/md/prbs_intf.md
+++ b/md/prbs_intf.md
@@ -1,17 +1,17 @@
 | Name                       | Signed? | Packed Dim      | Unpacked Dim   | Clock Domain | JTAG Dir | Reset Val                                    |
 |----------------------------|---------|-----------------|----------------|--------------|----------|----------------------------------------------|
-| prbs_cke                   |         |                 |                | Test         | out      | 1                                            |
-| prbs_eqn                   |         | Nprbs-1:0       |                | Test         | out      | 'b00000000000000000000000001100000           |
-| prbs_chan_sel              |         | Nti-1:0         |                | Test         | out      | 'hFFFF                                       |
-| prbs_inv_chicken           |         | 1:0             |                | Test         | out      | 'b00                                         |
-| prbs_checker_mode          |         | 1:0             |                | Test         | out      | 'b00                                         |
+| prbs_cke                   |         |                 |                | System       | out      | 1                                            |
+| prbs_eqn                   |         | Nprbs-1:0       |                | System       | out      | 'b00000000000000000000000001100000           |
+| prbs_chan_sel              |         | Nti-1:0         |                | System       | out      | 'hFFFF                                       |
+| prbs_inv_chicken           |         | 1:0             |                | System       | out      | 'b00                                         |
+| prbs_checker_mode          |         | 1:0             |                | System       | out      | 'b00                                         |
 | prbs_err_bits_upper        |         | 31:0            |                | System       | in       |                                              |
 | prbs_err_bits_lower        |         | 31:0            |                | System       | in       |                                              |
 | prbs_total_bits_upper      |         | 31:0            |                | System       | in       |                                              |
 | prbs_total_bits_lower      |         | 31:0            |                | System       | in       |                                              |
-| prbs_gen_cke               |         |                 |                | Test         | out      | 0                                            |
-| prbs_gen_init              |         | Nprbs-1:0       |                | Test         | out      | 'h00000001                                   |
-| prbs_gen_eqn               |         | Nprbs-1:0       |                | Test         | out      | 'b00000000000000000000000001100000           |
-| prbs_gen_inj_err           |         |                 |                | Test         | out      | 0                                            |
-| prbs_gen_chicken           |         | 1:0             |                | Test         | out      | 'b00                                         |
+| prbs_gen_cke               |         |                 |                | System       | out      | 0                                            |
+| prbs_gen_init              |         | Nprbs-1:0       |                | System       | out      | 'h00000001                                   |
+| prbs_gen_eqn               |         | Nprbs-1:0       |                | System       | out      | 'b00000000000000000000000001100000           |
+| prbs_gen_inj_err           |         |                 |                | System       | out      | 0                                            |
+| prbs_gen_chicken           |         | 1:0             |                | System       | out      | 'b00                                         |
 

--- a/tests/cpu_system_tests/loopback_sram_int/test.sv
+++ b/tests/cpu_system_tests/loopback_sram_int/test.sv
@@ -37,9 +37,6 @@ module test;
     localparam integer Nwrite = (2**(N_mem_addr+$clog2(N_mem_tiles)))*1.1;
     localparam integer Nread = 1024;
 
-    localparam [31:0] dump_off = 4'b0100;
-    localparam [31:0] dump_on  = 4'b1100;
-
 	// clock inputs
 
 	logic ext_clkp;
@@ -244,11 +241,11 @@ module test;
 
 		// Trigger dump and record input for awhile
 		should_record = 1'b1;
-		`FORCE_JTAG(misc_ctrl_bits, dump_on);
+		`FORCE_JTAG(en_int_dump_start, 1'b1);
+		`FORCE_JTAG(int_dump_start, 1'b1);
 		for (int k=0; k<(`N_INTERVAL); k=k+1) begin
 		    $display("Test is %0.1f%% complete.", (100.0*k)/(1.0*(`N_INTERVAL)));
 		    #((`INTERVAL_LENGTH)*1s);
-            if (k == 0) `FORCE_JTAG(misc_ctrl_bits, dump_off);
 		end
 
         // Read from SRAM

--- a/tests/cpu_system_tests/mm_cdr_slew/test.sv
+++ b/tests/cpu_system_tests/mm_cdr_slew/test.sv
@@ -255,7 +255,7 @@ module test;
 
         // Configure the CDR
       	$display("Configuring the CDR...");
-      	`FORCE_JTAG(misc_ctrl_bits, 'b10000);  // enable CDR clamping
+      	`FORCE_JTAG(cdr_en_clamp, 1'b1);  // enable CDR clamping
       	`FORCE_JTAG(Kp, 21);  // very high value so that we hit clamping behavior
       	`FORCE_JTAG(Ki, 0);
       	`FORCE_JTAG(invert, 1);

--- a/tests/fpga_system_tests/emu/test_emu.py
+++ b/tests/fpga_system_tests/emu/test_emu.py
@@ -346,15 +346,15 @@ def test_6(prbs_test_dur, jitter_rms, noise_rms, chan_tau, chan_delay):
 
     # Set the equation for the PRBS checker
     print('Setting the PRBS equation')
-    write_tc_reg('prbs_eqn', 0x100002)  # matches equation used by prbs21 in DaVE
+    write_sc_reg('prbs_eqn', 0x100002)  # matches equation used by prbs21 in DaVE
 
     # Configure PRBS checker
     print('Configure the PRBS checker')
-    write_tc_reg('sel_prbs_mux', 1) # "0" is ADC, "1" is FFE, "3" is BIST
+    write_sc_reg('sel_prbs_mux', 1) # "0" is ADC, "1" is FFE, "3" is BIST
 
     # Release the PRBS checker from reset
     print('Release the PRBS checker from reset')
-    write_tc_reg('prbs_rstb', 1)
+    write_sc_reg('prbs_rstb', 1)
 
     # Set up the FFE
     dt=1.0/(16.0e9)
@@ -417,9 +417,9 @@ def test_6(prbs_test_dur, jitter_rms, noise_rms, chan_tau, chan_delay):
     # minimized by running the test for a longer period.
     print('Run PRBS test')
     t_start = time.time()
-    write_tc_reg('prbs_checker_mode', 2)
+    write_sc_reg('prbs_checker_mode', 2)
     time.sleep(prbs_test_dur)
-    write_tc_reg('prbs_checker_mode', 3)
+    write_sc_reg('prbs_checker_mode', 3)
     t_stop = time.time()
 
     # Print out duration of PRBS test

--- a/tests/fpga_system_tests/emu_macro/test_emu_macro.py
+++ b/tests/fpga_system_tests/emu_macro/test_emu_macro.py
@@ -340,15 +340,15 @@ def test_6(prbs_test_dur, jitter_rms, noise_rms, chan_tau, chan_delay):
 
     # Set the equation for the PRBS checker
     print('Setting the PRBS equation')
-    write_tc_reg('prbs_eqn', 0x100002)  # matches equation used by prbs21 in DaVE
+    write_sc_reg('prbs_eqn', 0x100002)  # matches equation used by prbs21 in DaVE
 
     # Configure PRBS checker
     print('Configure the PRBS checker')
-    write_tc_reg('sel_prbs_mux', 1) # "0" is ADC, "1" is FFE, "3" is BIST
+    write_sc_reg('sel_prbs_mux', 1) # "0" is ADC, "1" is FFE, "3" is BIST
 
     # Release the PRBS checker from reset
     print('Release the PRBS checker from reset')
-    write_tc_reg('prbs_rstb', 1)
+    write_sc_reg('prbs_rstb', 1)
 
     # Set up the FFE
     dt=1.0/(16.0e9)
@@ -411,9 +411,9 @@ def test_6(prbs_test_dur, jitter_rms, noise_rms, chan_tau, chan_delay):
     # minimized by running the test for a longer period.
     print('Run PRBS test')
     t_start = time.time()
-    write_tc_reg('prbs_checker_mode', 2)
+    write_sc_reg('prbs_checker_mode', 2)
     time.sleep(prbs_test_dur)
-    write_tc_reg('prbs_checker_mode', 3)
+    write_sc_reg('prbs_checker_mode', 3)
     t_stop = time.time()
 
     # Print out duration of PRBS test

--- a/vlog/chip_src/digital_core/dcore_debug_intf.sv
+++ b/vlog/chip_src/digital_core/dcore_debug_intf.sv
@@ -58,7 +58,10 @@ interface dcore_debug_intf import const_pack::*; (
 		logic [1:0] sel_prbs_mux;
         logic en_cgra_clk;
         logic signed [Nadc-1:0] pfd_cal_ext_ave;
-        logic [31:0] misc_ctrl_bits;
+        logic pfd_cal_flip_feedback;
+        logic en_pfd_cal_ext_ave;
+        logic en_int_dump_start;
+        logic int_dump_start;
 
     modport dcore ( 	
 		input en_ext_pi_ctl_cdr,
@@ -104,7 +107,10 @@ interface dcore_debug_intf import const_pack::*; (
 		input sel_prbs_mux,
         input en_cgra_clk,
         input pfd_cal_ext_ave,
-        input misc_ctrl_bits,
+        input pfd_cal_flip_feedback,
+        input en_pfd_cal_ext_ave,
+        input en_int_dump_start,
+        input int_dump_start,
 
 		output adcout_avg ,
 		output adcout_sum,
@@ -161,7 +167,10 @@ interface dcore_debug_intf import const_pack::*; (
 		output sel_prbs_mux,
         output en_cgra_clk,
         output pfd_cal_ext_ave,
-        output misc_ctrl_bits,
+        output pfd_cal_flip_feedback,
+        output en_pfd_cal_ext_ave,
+        output en_int_dump_start,
+        output int_dump_start,
 
 		input adcout_avg ,
 		input adcout_sum,

--- a/vlog/chip_src/digital_core/digital_core.sv
+++ b/vlog/chip_src/digital_core/digital_core.sv
@@ -101,24 +101,12 @@ module digital_core import const_pack::*; (
     assign prbs_rstb        = ddbg_intf_i.prbs_rstb && ext_rstb;
     assign prbs_gen_rstb    = ddbg_intf_i.prbs_gen_rstb && ext_rstb;
 
-    // wire out miscellaneous control bits
-
-    logic pfd_cal_flip_feedback;
-    logic en_pfd_cal_ext_ave;
-    logic en_int_dump_start;
-    logic int_dump_start;
-    logic cdr_en_clamp;
-
-    assign pfd_cal_flip_feedback = ddbg_intf_i.misc_ctrl_bits[0];
-    assign en_pfd_cal_ext_ave    = ddbg_intf_i.misc_ctrl_bits[1];
-    assign en_int_dump_start     = ddbg_intf_i.misc_ctrl_bits[2];
-    assign int_dump_start        = ddbg_intf_i.misc_ctrl_bits[3];
-    assign cdr_en_clamp          = ddbg_intf_i.misc_ctrl_bits[4];
-
     // the dump_start signal can be set internally or externally
 
     logic dump_start;
-    assign dump_start = en_int_dump_start ? int_dump_start : ext_dump_start;
+    assign dump_start = (ddbg_intf_i.en_int_dump_start ?
+                         ddbg_intf_i.int_dump_start :
+                         ext_dump_start);
 
     // ADC Output Reordering
     // used to do retiming as well, but now that is handled in the analog core
@@ -176,8 +164,8 @@ module digital_core import const_pack::*; (
                 .Nbin(ddbg_intf_i.Nbin_adc),
                 .Navg(ddbg_intf_i.Navg_adc),
                 .DZ(ddbg_intf_i.DZ_hist_adc),
-                .flip_feedback(pfd_cal_flip_feedback),
-                .en_ext_ave(en_pfd_cal_ext_ave),
+                .flip_feedback(ddbg_intf_i.pfd_cal_flip_feedback),
+                .en_ext_ave(ddbg_intf_i.en_pfd_cal_ext_ave),
                 .ext_ave(ddbg_intf_i.pfd_cal_ext_ave),
                 .dout_avg(ddbg_intf_i.adcout_avg[k]),
                 .dout_sum(ddbg_intf_i.adcout_sum[k]),
@@ -249,7 +237,6 @@ module digital_core import const_pack::*; (
         .freq_lvl_cross(freq_lvl_cross),
         .pi_ctl(pi_ctl_cdr),
         .wait_on_reset_b(ctl_valid),
-        .en_clamp(cdr_en_clamp),
         .cdbg_intf_i(cdbg_intf_i)
     );
 

--- a/vlog/chip_src/jtag/jtag.sv
+++ b/vlog/chip_src/jtag/jtag.sv
@@ -195,7 +195,10 @@ module jtag (
 
     assign ddbg_intf_i.pfd_cal_ext_ave = rjtag_intf_i.pfd_cal_ext_ave;
 
-    assign ddbg_intf_i.misc_ctrl_bits = rjtag_intf_i.misc_ctrl_bits;
+    assign ddbg_intf_i.pfd_cal_flip_feedback = rjtag_intf_i.pfd_cal_flip_feedback;
+    assign ddbg_intf_i.en_pfd_cal_ext_ave = rjtag_intf_i.en_pfd_cal_ext_ave;
+    assign ddbg_intf_i.en_int_dump_start = rjtag_intf_i.en_int_dump_start;
+    assign ddbg_intf_i.int_dump_start = rjtag_intf_i.int_dump_start;
 
 	//Digital Output
 	assign rjtag_intf_i.adcout_avg=ddbg_intf_i.adcout_avg;
@@ -234,6 +237,7 @@ module jtag (
 	assign cdbg_intf_i.sel_inp_mux  = rjtag_intf_i.sel_inp_mux;
 	assign cdbg_intf_i.sample_state = rjtag_intf_i.sample_state;
 	assign cdbg_intf_i.invert = rjtag_intf_i.invert;
+    assign cdbg_intf_i.cdr_en_clamp = rjtag_intf_i.cdr_en_clamp;
     assign cdbg_intf_i.cdr_clamp_amt = rjtag_intf_i.cdr_clamp_amt;
 
 	//CDR Output

--- a/vlog/chip_src/mm_cdr/cdr_debug_intf.sv
+++ b/vlog/chip_src/mm_cdr/cdr_debug_intf.sv
@@ -20,6 +20,7 @@ interface cdr_debug_intf;
 	logic sample_state;
 	logic invert;
 
+    logic cdr_en_clamp;
     logic signed [31:0] cdr_clamp_amt;
 
 	modport cdr (
@@ -37,6 +38,7 @@ interface cdr_debug_intf;
 	 input sel_inp_mux,
 	 input sample_state,
 	 input invert,
+	 input cdr_en_clamp,
      input cdr_clamp_amt
 	);
 
@@ -55,6 +57,7 @@ interface cdr_debug_intf;
      output sel_inp_mux,
 	 output sample_state,
 	 output invert,
+     output cdr_en_clamp,
 	 output cdr_clamp_amt
 	);
 

--- a/vlog/chip_src/mm_cdr/mm_cdr.sv
+++ b/vlog/chip_src/mm_cdr/mm_cdr.sv
@@ -16,7 +16,6 @@ module mm_cdr import const_pack::*; #(
     output logic freq_lvl_cross,
     output logic wait_on_reset_b,
 
-    input wire logic en_clamp,
     cdr_debug_intf.cdr cdbg_intf_i
 );
 
@@ -111,7 +110,7 @@ module mm_cdr import const_pack::*; #(
         phase_est_update = ((phase_error << Kp) + freq_est_q);
 
         // clamp the phase update, if requested
-        if (en_clamp) begin
+        if (cdbg_intf_i.cdr_en_clamp) begin
             if (phase_est_update < clamp_min) begin
                 phase_update_clamped = clamp_min;
             end else if (phase_est_update > clamp_max) begin


### PR DESCRIPTION
This small PR does two things:
1. It replaces the ``misc_ctrl_bits`` JTAG register with single-bit registers ``cdr_en_clamp``, ``pfd_cal_flip_feedback``, ``en_pfd_cal_ext_ave``, ``en_int_dump_start``, and ``int_dump_start``.  This should make it easier to use these features.
2. PRBS debug I/O is moved from the ``Test`` to the ``System`` clock domain.  In general, we should review the JTAG clock domain assignments to make sure there are not initialization or synchronization hazards.  However, I have only done this for the PRBS and histogram circuitry because I am familiar with it.