### PR TITLE
Update clock constraints for TX

### DIFF
--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -106,10 +106,10 @@ set_clock_uncertainty -setup 0.02 clk_tx_hr_1
 set_clock_uncertainty -hold 0.02 clk_tx_hr_1
 
 # quarter rate
-set_clock_uncertainty -setup 0.01 clk_tx_qr_0
-set_clock_uncertainty -hold 0.01 clk_tx_qr_0
-set_clock_uncertainty -setup 0.01 clk_tx_qr_1
-set_clock_uncertainty -hold 0.01 clk_tx_qr_1
+set_clock_uncertainty -setup 0.03 clk_tx_qr_0
+set_clock_uncertainty -hold 0.03 clk_tx_qr_0
+set_clock_uncertainty -setup 0.03 clk_tx_qr_1
+set_clock_uncertainty -hold 0.03 clk_tx_qr_1
 
 ################
 # JTAG interface
@@ -199,6 +199,8 @@ set ext_false_path_only {{ \\
     ext_rstb \\
     ext_dump_start \\
     clk_cgra \\
+    ramp_clock \\
+    freq_lvl_cross \\
 }}
 
 set_false_path -through [get_ports $ext_false_path_only]
@@ -290,12 +292,12 @@ set_max_capacitance {1.0*cap_scale} [get_port ext_Vcal]
 # Tighten transition constraint for clocks declared so far
 set_max_transition {0.1*time_scale} -clock_path [get_clock clk_jtag]
 set_max_transition {0.1*time_scale} -clock_path [get_clock clk_retimer]
-set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_pi_0]
-set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_pi_1]
-set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_pi_2]
-set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_pi_3]
-set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_hr_0]
-set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_hr_1]
+set_max_transition {0.025*time_scale} -clock_path [get_clock clk_tx_pi_0]
+set_max_transition {0.025*time_scale} -clock_path [get_clock clk_tx_pi_1]
+set_max_transition {0.025*time_scale} -clock_path [get_clock clk_tx_pi_2]
+set_max_transition {0.025*time_scale} -clock_path [get_clock clk_tx_pi_3]
+set_max_transition {0.05*time_scale} -clock_path [get_clock clk_tx_hr_0]
+set_max_transition {0.05*time_scale} -clock_path [get_clock clk_tx_hr_1]
 set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_qr_0]
 set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_qr_1]
 
@@ -305,13 +307,13 @@ set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_qr_1]
 # (appears to be related to the fact that these are internal nets)
 
 foreach x [get_object_name $adbg_clk_pins] {{
-    create_clock -name clk_mon_net_$x -period {0.25*time_scale} [get_pins $x]
-    set_max_transition {0.025*time_scale} -clock_path [get_clocks clk_mon_net_$x]
+    # create_clock -name clk_mon_net_$x -period {0.25*time_scale} [get_pins $x]
+    set_max_transition {0.025*time_scale} [get_pins $x]
 }}
 
 foreach x [get_object_name $tdbg_clk_pins] {{
-    create_clock -name tx_clk_mon_net_$x -period {0.25*time_scale} [get_pins $x]
-    set_max_transition {0.025*time_scale} -clock_path [get_clocks tx_clk_mon_net_$x]
+    # create_clock -name tx_clk_mon_net_$x -period {0.25*time_scale} [get_pins $x]
+    set_max_transition {0.025*time_scale} [get_pins $x]
 }}
 
 #######################################################################

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -302,17 +302,13 @@ set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_qr_0]
 set_max_transition {0.1*time_scale} -clock_path [get_clock clk_tx_qr_1]
 
 # Set transition time for high-speed signals monitored from iacore and itx
-# transition time is 10% of a 4 GHz period.  Note that we have to
-# create a clock before the transition constraint is applied
-# (appears to be related to the fact that these are internal nets)
+# transition time is 10% of a 4 GHz period.
 
 foreach x [get_object_name $adbg_clk_pins] {{
-    # create_clock -name clk_mon_net_$x -period {0.25*time_scale} [get_pins $x]
     set_max_transition {0.025*time_scale} [get_pins $x]
 }}
 
 foreach x [get_object_name $tdbg_clk_pins] {{
-    # create_clock -name tx_clk_mon_net_$x -period {0.25*time_scale} [get_pins $x]
     set_max_transition {0.025*time_scale} [get_pins $x]
 }}
 

--- a/tests/cpu_system_tests/tx_loopback/test.sv
+++ b/tests/cpu_system_tests/tx_loopback/test.sv
@@ -142,6 +142,8 @@ module test;
 
             // transmitter signals
             $shm_probe(top_i.itx);
+            $shm_probe(top_i.itx.clk_halfrate);
+            $shm_probe(top_i.itx.clk_halfrate_n);
 
             // PI controls
             $shm_probe(top_i.idcore.int_pi_ctl_cdr);

--- a/vlog/chip_src/tx_16t1/div_b2.sv
+++ b/vlog/chip_src/tx_16t1/div_b2.sv
@@ -1,5 +1,3 @@
-
-
 `default_nettype none
 
 module div_b2 (
@@ -8,11 +6,7 @@ module div_b2 (
     output reg clkout
 );
 
-initial begin
-    clkout = 1'b0;
-end
-
-always@(posedge clkin) begin
+always @(posedge clkin or posedge rst) begin
     if (rst) begin
         clkout <= 0;
     end else begin


### PR DESCRIPTION
## Summary

This PR updates the timing constraints for signals related to the TX.  It also removes a non-synthesizable ``initial`` block from ``div_b2``.

## Details

1. ``create_clock`` is used to declare four 4 GHz clocks at the outputs of the PIs in the TX.  They are given phase shifts of 0, 90, 180, and 270 degrees.
2. There are four clock dividers in the TX, and ``create_generated_clock`` is used to describe their behaviors.
3. The setup/hold clock uncertainty for all of these clocks (4 GHz, 2 GHz, and 1 GHz) are set to a few percent their period: The 1 GHz clocks are given an uncertainty of 30 ps, the 2 GHz clocks are given an uncertainty of 20 ps, and the 4 GHz clocks are given an uncertainty of 10 ps.
4. The TX clocks are grouped together with ``set_clock_groups``.  This means that clock domain crossings between the various TX clocks are analyzed, but crossings to other clocks (``clk_adc``, ``clk_jtag``, etc.) are not.
5. The maximum transition of TX clocks is set to 10% of their periods: 100ps for 1 GHz clocks, 50ps for 2 GHz clocks, and 25ps for 4 GHz clocks.
6. ``create_clock`` is not longer used for debug clock signals that are monitored with the ``output_buffer``.  Those nets are now treated as regular signals, but given a stricter-than-default ``max_transition`` of 25ps (i.e., 10% of the 4 GHz period)