### PR TITLE
Fix non-deterministic register map

### DIFF
--- a/dragonphy/__init__.py
+++ b/dragonphy/__init__.py
@@ -1,3 +1,18 @@
+# Check versions of critical packages
+# TODO: is there a cleaner way to do this?  We currently
+# need to define this in two places -- setup.py and here
+import pkg_resources
+REQUIRED_PACKAGE_VERSIONS = [
+    ('justag', '0.0.4.5'),
+    ('svinst' , '0.1.5')
+]
+for name, version in REQUIRED_PACKAGE_VERSIONS:
+    assert pkg_resources.get_distribution(name).version == version, (
+            f'{name} version does not match {version}.  ' +
+            f'Please use pip install -e . to reinstall DragonPHY, ' +
+            f'and check there are no errors.'
+    )
+
 # Some Quality Of Life Libraries
 from .real_type      import get_dragonphy_real_type, add_placeholder_inputs
 from .sparams        import s4p_to_impulse, s4p_to_step

--- a/experiments/jtag_deterministic/test.py
+++ b/experiments/jtag_deterministic/test.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+import shutil
+import os
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+TOP_DIR = THIS_DIR.parent.parent
+BUILD_DIR = TOP_DIR / 'build'
+
+NUM_TRIALS = 25
+
+def run_trial():
+    cwd = os.getcwd()
+    os.chdir(TOP_DIR)
+
+    shutil.rmtree(BUILD_DIR, ignore_errors=True)
+    python = sys.executable
+    result = subprocess.run([python, 'make.py', '--view', 'asic'],
+                            capture_output=True)
+
+    assert result.returncode == 0, 'JusTAG failed to run.'
+
+    with open(BUILD_DIR / 'all' / 'jtag' / 'reg_list.json', 'r') as f:
+        text = f.read()
+
+    os.chdir(cwd)
+    return text
+
+# run reference
+print(f'Reference run...')
+ref_text = run_trial()
+
+# main trials
+for k in range(NUM_TRIALS):
+    print(f'Running trial {k}...')
+    trial_text = run_trial()
+    print(f'Checking trial {k}...')
+    assert trial_text == ref_text, f'Failed at trial {k}'
+    print('OK')

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requires_list = [
     'lxml',
     'scikit-rf',
     'BeautifulSoup4',
-    'justag==0.0.4.4',
+    'justag==0.0.4.5',
     # general requirements with special versions to prevent
     # warnings that clutter pytest output
     'jinja2>=2.11.1',


### PR DESCRIPTION
## Summary
This small PR resolves issue #131 by making the JTAG register map deterministic.  

## Details
1. Updates **justag** to **0.0.4.5**, which fixes the underlying issue.
2. Enforces the use of **justag** **0.0.4.5** (i.e., will not generate a register map if the version is not right)
3. Adds some code in the **experiments** directory that can be used to check if the register map generation process is repeatable.