### PR TITLE
Fix TX synthesis bug

### DIFF
--- a/designs/dragonphy_top/constraints/configure.yml
+++ b/designs/dragonphy_top/constraints/configure.yml
@@ -18,7 +18,7 @@ parameters:
 
   # Period of the main clock in nanoseconds
   # (will be scaled by constr_time_scale)
-  constr_main_per: 0.7
+  constr_main_per: 0.9
 
   # Scale factor for timing constraints
   constr_time_scale: 1.0

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -274,6 +274,8 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
 for {{set i 0}} {{$i < 2}} {{incr i}} {{
     set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_n/tri_buf"]
     set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_p/tri_buf"]
+    set_false_path -through [get_pins -of_objects "itx/buf1/iBUF[$i].i_tri_buf_n/tri_buf"]
+    set_false_path -through [get_pins -of_objects "itx/buf1/iBUF[$i].i_tri_buf_p/tri_buf"]
 }}
 set_dont_touch [get_nets "itx/buf1/BTN"]
 set_dont_touch [get_nets "itx/buf1/BTP"]
@@ -284,6 +286,10 @@ set_dont_touch [get_cells "itx/buf1/i_term_p"]
 # a combinational loop error
 set_false_path -through [get_pins -of_objects "itx/buf1/i_term_n"]
 set_false_path -through [get_pins -of_objects "itx/buf1/i_term_p"]
+
+# Make sure the transmitter is not retimed.  This may already be in
+# the main DC step, but it's not clear that it's being applied.
+set_dont_retime [get_cells itx]
 
 ######
 # MDLL
@@ -383,14 +389,14 @@ set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_0/din[0]}}]
 set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_0/din[1]}}]
 set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_0/din[2]}}]
 set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_0/din[3]}}]
-set_max_transition {0.00625*time_scale} [get_pin {{itx/qr_mux_4t1_0/data}}]
+set_max_transition {0.008*time_scale} [get_pin {{itx/qr_mux_4t1_0/data}}]
 
 # Mux -
 set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_1/din[0]}}]
 set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_1/din[1]}}]
 set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_1/din[2]}}]
 set_max_transition {0.025*time_scale} [get_pin {{itx/qr_mux_4t1_1/din[3]}}]
-set_max_transition {0.00625*time_scale} [get_pin {{itx/qr_mux_4t1_1/data}}]
+set_max_transition {0.008*time_scale} [get_pin {{itx/qr_mux_4t1_1/data}}]
 
 echo [all_clocks]
 '''

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -242,15 +242,19 @@ for {{set i 0}} {{$i < 4}} {{incr i}} {{
 # Input divider
 set_dont_touch [get_cells itx/indiv]
 
+# Internal nets
+set_dont_touch [get_nets "itx/qr_data_p"]
+set_dont_touch [get_nets "itx/qr_data_n"]
+set_dont_touch [get_nets "itx/mtb_n"]
+set_dont_touch [get_nets "itx/mtb_p"]
+
 # Muxes
 for {{set i 0}} {{$i < 2}} {{incr i}} {{
     # Half-rate muxes (the mux is intentionally left out because
     # there is a mapping problem for FreePDK45
     for {{set j 1}} {{$j < 5}} {{incr j}} {{
+        set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hd"]
         for {{set k 0}} {{$k < 3}} {{incr k}} {{
-            set_dont_touch [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/clk_b"]
-            set_dont_touch [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/din"]
-            set_dont_touch [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dout"]
             set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/D0L"]
             set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/D1M"]
             set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/L0M"]
@@ -258,13 +262,6 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
     }}
 
     # Quarter-rate muxes
-    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_Q"]
-    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_QB"]
-    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_I"]
-    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_IB"]
-    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/din"]
-    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/rst"]
-    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/data"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D0DQ"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D0DI"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D0DQB"]
@@ -275,13 +272,13 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
 
 # Output buffer
 for {{set i 0}} {{$i < 2}} {{incr i}} {{
-    set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_n"]
-    set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_p"]
+    set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_n/tri_buf"]
+    set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_p/tri_buf"]
 }}
-set_dont_touch [get_nets itx/buf1/BTN]
-set_dont_touch [get_nets itx/buf1/BTP]
-set_dont_touch [get_cells itx/buf1/i_term_n]
-set_dont_touch [get_cells itx/buf1/i_term_p]
+set_dont_touch [get_nets "itx/buf1/BTN"]
+set_dont_touch [get_nets "itx/buf1/BTP"]
+set_dont_touch [get_cells "itx/buf1/i_term_n"]
+set_dont_touch [get_cells "itx/buf1/i_term_p"]
 
 ######
 # MDLL

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -251,6 +251,7 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
             set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dff_0"]
             set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dff_1"]
             set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/latch_0"]
+            set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/mux_0"]
         }}
     }}
 

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -234,9 +234,6 @@ set_dont_touch_network $tdbg_clk_pins
 # TODO: do we need to set dont_touch through the hierarchy?
 # Or will it be applied automatically to instances within?
 
-# TX top
-set_dont_touch [get_cells itx]
-
 # Phase interpolators
 for {{set i 0}} {{$i < 4}} {{incr i}} {{
     set_dont_touch [get_cells "itx/iPI[$i].iPI"]
@@ -247,21 +244,17 @@ set_dont_touch [get_cells itx/indiv]
 
 # Muxes
 for {{set i 0}} {{$i < 2}} {{incr i}} {{
-    # Half-rate muxes
-    set_dont_touch [get_cells "itx/hr_mux_16t4_$i"]
+    # Half-rate muxes (the mux is intentionally left out because
+    # there is a mapping problem for FreePDK45
     for {{set j 1}} {{$j < 5}} {{incr j}} {{
-        set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1"]
         for {{set k 0}} {{$k < 3}} {{incr k}} {{
-            set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k"]
             set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dff_0"]
             set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dff_1"]
             set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/latch_0"]
-            set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/mux_0"]
         }}
     }}
 
     # Quarter-rate muxes
-    set_dont_touch [get_cells "itx/qr_mux_4t1_$i"]
     set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_Q0"]
     set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_I0"]
     set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_QB0"]
@@ -277,11 +270,12 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
 }}
 
 # Output buffer
-set_dont_touch [get_cells itx/buf1]
 for {{set i 0}} {{$i < 2}} {{incr i}} {{
     set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_n"]
     set_dont_touch [get_cells "itx/buf1/iBUF[$i].i_tri_buf_p"]
 }}
+set_dont_touch [get_nets itx/buf1/BTN]
+set_dont_touch [get_nets itx/buf1/BTP]
 set_dont_touch [get_cells itx/buf1/i_term_n]
 set_dont_touch [get_cells itx/buf1/i_term_p]
 

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -248,20 +248,23 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
     # there is a mapping problem for FreePDK45
     for {{set j 1}} {{$j < 5}} {{incr j}} {{
         for {{set k 0}} {{$k < 3}} {{incr k}} {{
-            set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dff_0"]
-            set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dff_1"]
-            set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/latch_0"]
-            set_dont_touch [get_cells "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/mux_0"]
+            set_dont_touch [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/clk_b"]
+            set_dont_touch [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/din"]
+            set_dont_touch [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/dout"]
+            set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/D0L"]
+            set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/D1M"]
+            set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/L0M"]
         }}
     }}
 
     # Quarter-rate muxes
-    set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_Q0"]
-    set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_I0"]
-    set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_QB0"]
-    set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_QB1"]
-    set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_IB0"]
-    set_dont_touch [get_cells "itx/qr_mux_4t1_$i/dff_IB1"]
+    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_Q"]
+    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_QB"]
+    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_I"]
+    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/clk_IB"]
+    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/din"]
+    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/rst"]
+    set_dont_touch [get_pins "itx/qr_mux_4t1_$i/data"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D0DQ"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D0DI"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D0DQB"]

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -280,6 +280,11 @@ set_dont_touch [get_nets "itx/buf1/BTP"]
 set_dont_touch [get_cells "itx/buf1/i_term_n"]
 set_dont_touch [get_cells "itx/buf1/i_term_p"]
 
+# Set a false path on the termination resistors to avoid
+# a combinational loop error
+set_false_path -through [get_pins -of_objects "itx/buf1/i_term_n"]
+set_false_path -through [get_pins -of_objects "itx/buf1/i_term_p"]
+
 ######
 # MDLL
 ######

--- a/designs/dragonphy_top/qtm/termination.qtm.tcl
+++ b/designs/dragonphy_top/qtm/termination.qtm.tcl
@@ -12,14 +12,15 @@ set_qtm_technology -library $::env(qtm_tech_lib)
 create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
 create_qtm_load_type -lib_cell $ADK_DRIVING_CELL qtm_load
 
-# define inputs
-set input_list { \
- VinP \
- VinN \
- Vcm \
+# define inouts
+set inout_list { \
+    VinP \
+    VinN \
+    Vcm \
 }
-create_qtm_port $input_list -type input
-set_qtm_port_load -type qtm_load -factor 2 $input_list
+create_qtm_port $inout_list -type inout
+set_qtm_port_load -type qtm_load -factor 2 $inout_list
+set_qtm_port_drive -type qtm_drive $inout_list
 
 report_qtm_model
 save_qtm_model -format {lib db} -library_cell

--- a/designs/dragonphy_top/qtm/termination.qtm.tcl
+++ b/designs/dragonphy_top/qtm/termination.qtm.tcl
@@ -12,15 +12,20 @@ set_qtm_technology -library $::env(qtm_tech_lib)
 create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
 create_qtm_load_type -lib_cell $ADK_DRIVING_CELL qtm_load
 
-# define inouts
-set inout_list { \
+# define input(s)
+set input_list { \
     VinP \
     VinN \
+}
+create_qtm_port $input_list -type input
+set_qtm_port_load -type qtm_load -factor 2 $input_list
+
+# define output(s)
+set output_list { \
     Vcm \
 }
-create_qtm_port $inout_list -type inout
-set_qtm_port_load -type qtm_load -factor 2 $inout_list
-set_qtm_port_drive -type qtm_drive $inout_list
+create_qtm_port $output_list -type output
+set_qtm_port_drive -type qtm_drive $output_list
 
 report_qtm_model
 save_qtm_model -format {lib db} -library_cell

--- a/vlog/chip_src/tx_16t1/hr_16t4_mux_top.sv
+++ b/vlog/chip_src/tx_16t1/hr_16t4_mux_top.sv
@@ -14,7 +14,7 @@ module hr_16t4_mux_top (  // The output data rate should be input clock frequenc
 
 genvar i;
 generate  // Instantiate 4 hr_4t1_mux_top to form 16:4 mux
-    for (i=1; i<5; i=i+1) begin
+    for (i=1; i<5; i=i+1) begin : iMUX
         hr_4t1_mux_top mux_4t1 (
             .clk_b(clk_hr),
             .din(din[4*i-1:4*(i-1)]),  // Map 16 bits input to 4 half-rate 4 to 1 mux

--- a/vlog/chip_src/tx_16t1/hr_2t1_mux_top.sv
+++ b/vlog/chip_src/tx_16t1/hr_2t1_mux_top.sv
@@ -10,7 +10,6 @@ module hr_2t1_mux_top (
     output wire logic dout
 );
 
-// wire [1:0] din;
 wire D0L; // din[0] wire connection from DFF to D-Latch
 wire D1M; // din[1] wire connection from DFF to MUX
 wire L0M; // din[0] wire connection from D-Latch to MUX

--- a/vlog/chip_src/tx_16t1/hr_2t1_mux_top.sv
+++ b/vlog/chip_src/tx_16t1/hr_2t1_mux_top.sv
@@ -17,8 +17,8 @@ wire L0M; // din[0] wire connection from D-Latch to MUX
 //Instantiate the DFF, latch and MUX
 ff_c dff_0 (.D(din[0]), .CP(clk_b), .Q(D0L)); // DFF on din[0] path
 ff_c dff_1 (.D(din[1]), .CP(clk_b), .Q(D1M)); // DFF on din[0] path
-dlatch_n latch_0 (clk_b, D0L, L0M); // D-Latch after din[0] 
-mux mux_0 (L0M, D1M, clk_b, dout);
+dlatch_n latch_0 (.clk(clk_b), .din(D0L), .dout(L0M)); // D-Latch after din[0]
+mux mux_0 (.in0(L0M), .in1(D1M), .sel(clk_b), .out(dout));
 
 endmodule
 

--- a/vlog/chip_src/tx_16t1/output_buf_tx.sv
+++ b/vlog/chip_src/tx_16t1/output_buf_tx.sv
@@ -52,15 +52,15 @@ module output_buf_tx (
     /////////////////
     
     termination i_term_n (
-        .Vcm(BTN),
-        .VinP(DOUTN),
-        .VinN(DOUTN)
+        .VinP(BTN),
+        .VinN(BTN),
+        .Vcm(DOUTN)
     );
 
     termination i_term_p (
-        .Vcm(BTP),
-        .VinP(DOUTP),
-        .VinN(DOUTP)
+        .VinP(BTP),
+        .VinN(BTP),
+        .Vcm(DOUTP)
     );
 
 endmodule

--- a/vlog/chip_src/tx_16t1/qr_4t1_mux_top_2DFF.sv
+++ b/vlog/chip_src/tx_16t1/qr_4t1_mux_top_2DFF.sv
@@ -14,25 +14,21 @@ module qr_4t1_mux_top_2DFF (
 
 // Instantiate the data path for Q clk path, use the Q clock as the reference clock
 wire D0DQ;
-wire D1MQ;
 ff_c dff_Q0 (.D(din[3]), .CP(clk_Q), .Q(D0DQ));
 
 // Instantiate the data path for I clk path
 wire D0DI;
-wire D1MI;
 ff_c dff_I0 (.D(din[2]), .CP(clk_I), .Q(D0DI));
 
 // Instantiate the data path for QB clk path
 wire D0DQB;
 wire D1DQB;
-wire D2MQB;
 ff_c dff_QB0 (.D(din[1]), .CP(clk_Q), .Q(D0DQB)); // data captured using Q clk and gradually passed to QB clk.
 ff_c dff_QB1 (.D(D0DQB), .CP(clk_QB), .Q(D1DQB));
 
 // Instantiate the data path for QB clk path
 wire D0DIB;
 wire D1DIB;
-wire D2MIB;
 ff_c dff_IB0 (.D(din[0]), .CP(clk_I), .Q(D0DIB)); // data captured using Q clk and gradually passed to IB clk.
 ff_c dff_IB1 (.D(D0DIB), .CP(clk_IB), .Q(D1DIB));
 


### PR DESCRIPTION
## Summary
I examined the synthesis output (for FreePDK45) and noticed a big problem -- most of the TX mux and output driver was missing.  This PR aims to fix that by applying ``dont_touch`` to some nets and cells in the transmitter.

There was also an unrelated problem, where the synthesis tool did not connect ``termination`` resistors to the DragonPHY output pins, because the ``*.lib`` file for the resistor had all pins marked as ``input``.  For now, I marked ``VinP`` and ``VinN`` as ``input`` and ``Vcm`` as ``output`` (marking all as ``inout`` caused a different issue having to do with combo loop detection).

Of course, someone with process access will need to verify these changes on the real process to be used for tapeout, to make sure that these changes fix the problem.

## Details
1. Per feedback from @zamyers: The transition time constraint for 16 GHz outputs of the TX mux is relaxed to 8ps from 6.25ps.  In addition, the target clock period is increased from 0.7 ns to 0.9 ns.
2. I noticed that when ``set_max_transition`` was being applied to pins of black boxes (analog core, MDLL, etc.), this caused a warning, and the constraint was not applied.  This PR does not solve that problem, but it at least comments out the problematic commands.
3. It looks like there is still a problem with the tool inserting a buffer after the termination resistor.  That will have to be solved in another PR. 