### PR TITLE
Fix missing output driver information

### DIFF
--- a/designs/dragonphy_top/qtm/analog_core.qtm.tcl
+++ b/designs/dragonphy_top/qtm/analog_core.qtm.tcl
@@ -298,6 +298,18 @@ set_qtm_port_load -type qtm_load -factor 2 { adbg_intf_i.sign_PFD_clk_in_rep[1:0
 
 ###################### Timing Arcs ######################
 
+## Clock outputs
+
+create_qtm_delay_arc -from ext_clk -edge rise -to clk_adc -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.del_out_pi -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.pi_out_meas[0] -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.pi_out_meas[1] -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.pi_out_meas[2] -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.pi_out_meas[3] -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.del_out_rep[0] -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.del_out_rep[1] -value 0
+create_qtm_delay_arc -from ext_clk -edge rise -to adbg_intf_i.inbuf_out_meas -value 0
+
 ## PI control signals
 
 # setup/hold for ctl_valid

--- a/designs/dragonphy_top/qtm/input_buffer.qtm.tcl
+++ b/designs/dragonphy_top/qtm/input_buffer.qtm.tcl
@@ -12,13 +12,22 @@ set_qtm_global_parameter -param clk_to_output -value 0.0
 create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
 create_qtm_load_type -lib_cell $ADK_DRIVING_CELL qtm_load
 
-set input_list {inp inm pd}
+set clock_list {inp inm}
+create_qtm_port $clock_list -type clock
+set_qtm_port_load -type qtm_load -factor 2 $clock_list
+
+set input_list {pd}
 create_qtm_port $input_list -type input
 set_qtm_port_load -type qtm_load -factor 2 $input_list
 
 set output_list {clk clk_b}
 create_qtm_port $output_list -type output
 set_qtm_port_drive -type qtm_drive $output_list
+
+# these arcs are required to cause driver information
+# to be placed in the resulting *.lib file
+create_qtm_delay_arc -from inp -edge rise -to clk -value 0
+create_qtm_delay_arc -from inm -edge rise -to clk_b -value 0
 
 report_qtm_model
 save_qtm_model -format {lib db} -library_cell

--- a/designs/dragonphy_top/qtm/input_divider.qtm.tcl
+++ b/designs/dragonphy_top/qtm/input_divider.qtm.tcl
@@ -12,27 +12,38 @@ set_qtm_technology -library $::env(qtm_tech_lib)
 create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
 create_qtm_load_type -lib_cell $ADK_DRIVING_CELL qtm_load
 
+# define clocks
+set clock_list { \
+    in \
+    in_mdll \
+}
+create_qtm_port $clock_list -type clock
+set_qtm_port_load -type qtm_load -factor 2 $clock_list
+
 # define inputs
 set input_list { \
- in \
- in_mdll \
- sel_clk_source \
- en \
- en_meas \
- ndiv[2:0] \
- bypass_div \
- bypass_div2 \
+    sel_clk_source \
+    en \
+    en_meas \
+    ndiv[2:0] \
+    bypass_div \
+    bypass_div2 \
 }
 create_qtm_port $input_list -type input
 set_qtm_port_load -type qtm_load -factor 2 $input_list
 
 # define outputs
 set output_list { \
- out \
- out_meas \
+    out \
+    out_meas \
 }
 create_qtm_port $output_list -type output
 set_qtm_port_drive -type qtm_drive $output_list
+
+# these arcs are required to cause driver information
+# to be placed in the resulting *.lib file
+create_qtm_delay_arc -from in -edge rise -to out -value 0
+create_qtm_delay_arc -from in -edge rise -to out_meas -value 0
 
 report_qtm_model
 save_qtm_model -format {lib db} -library_cell

--- a/designs/dragonphy_top/qtm/mdll_r1_top.qtm.tcl
+++ b/designs/dragonphy_top/qtm/mdll_r1_top.qtm.tcl
@@ -12,6 +12,16 @@ set_qtm_global_parameter -param clk_to_output -value 0.0
 create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
 create_qtm_load_type -lib_cell $ADK_DRIVING_CELL qtm_load
 
+# define clocks
+set clock_list { \
+    clk_refp \
+    clk_refn \
+    clk_monp \
+    clk_monn \
+}
+create_qtm_port $clock_list -type clock
+set_qtm_port_load -type qtm_load -factor 2 $clock_list
+
 # define inputs
 set input_list { \
     fb_ndiv_jtag[3:0] \
@@ -25,11 +35,7 @@ set input_list { \
     ctl_dac_bw_thm_jtag[6:0] \
     ctlb_dac_gain_oc_jtag[3:0] \
     jm_sel_clk_jtag[2:0] \
-    clk_refp \
-    clk_refn \
     rstn_jtag \
-    clk_monp \
-    clk_monn \
     en_osc_jtag \
     en_dac_sdm_jtag \
     en_monitor_jtag \
@@ -62,6 +68,13 @@ set output_list { \
 }
 create_qtm_port $output_list -type output
 set_qtm_port_drive -type qtm_drive $output_list
+
+# these arcs are required to cause driver information
+# to be placed in the resulting *.lib file
+create_qtm_delay_arc -from clk_refp -edge rise -to clk_0 -value 0
+create_qtm_delay_arc -from clk_refp -edge rise -to clk_90 -value 0
+create_qtm_delay_arc -from clk_refp -edge rise -to clk_180 -value 0
+create_qtm_delay_arc -from clk_refp -edge rise -to clk_270 -value 0
 
 report_qtm_model
 save_qtm_model -format {lib db} -library_cell

--- a/designs/dragonphy_top/qtm/mdll_r1_top.qtm.tcl
+++ b/designs/dragonphy_top/qtm/mdll_r1_top.qtm.tcl
@@ -9,7 +9,12 @@ set_qtm_global_parameter -param setup -value 0.0
 set_qtm_global_parameter -param hold -value 0.0
 set_qtm_global_parameter -param clk_to_output -value 0.0
 
-create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
+if { $::env(qtm_tech_lib) == "NangateOpenCellLibrary" } {
+    create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
+} else {
+    create_qtm_drive_type -lib_cell INVD1BWP16P90 qtm_drive
+}
+
 create_qtm_load_type -lib_cell $ADK_DRIVING_CELL qtm_load
 
 # define clocks

--- a/designs/dragonphy_top/qtm/phase_interpolator.qtm.tcl
+++ b/designs/dragonphy_top/qtm/phase_interpolator.qtm.tcl
@@ -12,12 +12,18 @@ set_qtm_technology -library $::env(qtm_tech_lib)
 create_qtm_drive_type -lib_cell $ADK_DRIVING_CELL qtm_drive
 create_qtm_load_type -lib_cell $ADK_DRIVING_CELL qtm_load
 
-# define inputs
-set input_list { \
-	rstb \
+# define clocks
+set clock_list { \
     clk_in \
     clk_async \
     clk_encoder \
+}
+create_qtm_port $clock_list -type clock
+set_qtm_port_load -type qtm_load -factor 2 $clock_list
+
+# define inputs
+set input_list { \
+	rstb \
     disable_state \
     en_arb \
     en_cal \
@@ -52,6 +58,11 @@ set output_list { \
 }
 create_qtm_port $output_list -type output
 set_qtm_port_drive -type qtm_drive $output_list
+
+# these arcs are required to cause driver information
+# to be placed in the resulting *.lib file
+create_qtm_delay_arc -from clk_in -edge rise -to clk_out_slice -value 0
+create_qtm_delay_arc -from clk_in -edge rise -to clk_out_sw -value 0
 
 report_qtm_model
 save_qtm_model -format {lib db} -library_cell


### PR DESCRIPTION
We discovered that output driver information was missing on most pins in ``*.lib`` files generated with QTM.  It turns out the reason is that QTM will not add driver information to outputs that have no timing arcs.  A quick fix is to add a dummy arc from one of the QTM pins declared **clock** (not **input**) to the output(s) of interest.  This PR does exactly that, for all black-box pins that have a **create_clock** statement applied to them in the top-level synthesis constraints.

My main concern is that these dummy arcs might cause problems in the timing analysis -- please check the synthesis & PnR results to make sure that is not the case.  In parallel, I can investigate whether there is a cleaner way to add this driver information.  However, it is not clear that there will be, so I suggest that we use this quick fix for now.