### PR TITLE
Add TX multicycle constraints

### DIFF
--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -326,6 +326,77 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D0DIB"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/D1DIB"]
     set_dont_touch [get_nets "itx/qr_mux_4t1_$i/mux_out"]
+
+    ####################
+    # Multicycle paths #
+    ####################
+ 
+    # all are launched on clk_tx_hr, which is
+    # divided by two from clk_tx_pi_2 (QB)
+
+    # din[0]: captured on I @ dff_IB0
+
+    set_multicycle_path \\
+        1 \\
+        -setup \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[0].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/CP"]
+
+    set_multicycle_path \\
+        0 \\
+        -hold \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[0].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/CP"]
+
+    # din[1]: captured on Q @ dff_QB0
+
+    set_multicycle_path \\
+        1 \\
+        -setup \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/CP"]
+
+    set_multicycle_path \\
+        0 \\
+        -hold \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/CP"]
+
+    # din[2]: captured on I @ dff_I0
+
+    set_multicycle_path \\
+        1 \\
+        -setup \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/CP"]
+
+    set_multicycle_path \\
+        0 \\
+        -hold \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/CP"]
+
+    # din[3]: captured on Q @ dff_Q0
+
+    set_multicycle_path \\
+        1 \\
+        -setup \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/CP"]
+
+    set_multicycle_path \\
+        0 \\
+        -hold \\
+        -end \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/CP"]
 '''
 
 if os.environ['adk_name'] == 'tsmc16':

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -311,6 +311,25 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
     # there is a mapping problem for FreePDK45
     for {{set j 1}} {{$j < 5}} {{incr j}} {{
         set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hd"]
+
+        # multipath constraint from quarter-rate to half-rate muxes
+        for {{set k 0}} {{$k < 2}} {{incr k}} {{
+            set_multicycle_path \\
+                1 \\
+                -setup \\
+                -end \\
+                -from [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/mux_0/sel"] \\
+                -to [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_2/dff_$k/D"]
+
+            set_multicycle_path \\
+                0 \\
+                -hold \\
+                -end \\
+                -from [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/mux_0/sel"] \\
+                -to [get_pins "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_2/dff_$k/D"]
+        }}
+
+        # dont_touch nets within each 2t1 mux
         for {{set k 0}} {{$k < 3}} {{incr k}} {{
             set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/D0L"]
             set_dont_touch [get_nets "itx/hr_mux_16t4_$i/iMUX[$j].mux_4t1/hr_2t1_mux_$k/D1M"]

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -340,14 +340,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         1 \\
         -setup \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[0].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/CP"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[0].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/CP"]
 
     # din[1]: captured on Q @ dff_QB0
@@ -356,14 +356,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         1 \\
         -setup \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/CP"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/CP"]
 
     # din[2]: captured on I @ dff_I0
@@ -372,14 +372,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         1 \\
         -setup \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/CP"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/CP"]
 
     # din[3]: captured on Q @ dff_Q0
@@ -388,14 +388,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         1 \\
         -setup \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[4].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/CP"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
-        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux0/sel"] \\
+        -from [get_pins "itx/hr_mux_16t4_$i/iMUX[4].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
         -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/CP"]
 '''
 

--- a/designs/dragonphy_top/constraints/gen_constraints.py
+++ b/designs/dragonphy_top/constraints/gen_constraints.py
@@ -341,14 +341,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         -setup \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/D"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[1].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_IB0/D"]
 
     # din[1]: captured on Q @ dff_QB0
 
@@ -357,14 +357,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         -setup \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/D"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[2].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_QB0/D"]
 
     # din[2]: captured on I @ dff_I0
 
@@ -373,14 +373,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         -setup \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/D"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[3].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_I0/D"]
 
     # din[3]: captured on Q @ dff_Q0
 
@@ -389,14 +389,14 @@ for {{set i 0}} {{$i < 2}} {{incr i}} {{
         -setup \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[4].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/D"]
 
     set_multicycle_path \\
         0 \\
         -hold \\
         -end \\
         -from [get_pins "itx/hr_mux_16t4_$i/iMUX[4].mux_4t1/hr_2t1_mux_2/mux_0/sel"] \\
-        -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/CP"]
+        -to [get_pins "itx/qr_mux_4t1_$i/dff_Q0/D"]
 '''
 
 if os.environ['adk_name'] == 'tsmc16':


### PR DESCRIPTION
This PR aims to resolve a hold time issue arising in CTS in the transmitter.  It appears that the default timing analysis of data being transferred from the half-rate clock to full-rate clock was not what we wanted, and I have attempted to fix that by using ``set_multicycle_path`` (which is really just a way of moving around the edges used for setup and hold checks).  I applied similar constraints to data being transferred from the quarter-rate clock to the half-rate clock.

@zamyers, please hold off on approving this PR until you can verify that the issue is resolved.  If more iteration is needed to solve the problem, I'll push those changes to this branch.  Thanks!