### PR TITLE
Transmitter hot fix

### DIFF
--- a/tests/cpu_block_tests/tx_top_sim/test.sv
+++ b/tests/cpu_block_tests/tx_top_sim/test.sv
@@ -421,35 +421,35 @@ end
             count_flag[6] <= 8'b0;
             count_flag[7] <= 8'b0;
         end else if (record_flag[0]) begin
-            #0.75ns;  // Manually align the count down with the first bit of the data output, this delay should be fixed if no circuit connection has changed
+            #0.5ns;  // Manually align the count down with the first bit of the data output, this delay should be fixed if no circuit connection has changed
             count_flag[0] = 8'd16; // determine how many bits to store in the shift reg
             record_flag[0] = 1'b0;
         end else if (record_flag[1]) begin
-            #0.75ns;
+            #0.5ns;
             count_flag[1] = 8'd16;
             record_flag[1] = 1'b0;
         end else if (record_flag[2]) begin
-            #0.75ns;
+            #0.5ns;
             count_flag[2] = 8'd16;
             record_flag[2] = 1'b0;
         end else if (record_flag[3]) begin
-            #0.75ns;
+            #0.5ns;
             count_flag[3] = 8'd16;
             record_flag[3] = 1'b0;
         end else if (record_flag[4]) begin
-            #0.75ns;
+            #0.5ns;
             count_flag[4] = 8'd16;
             record_flag[4] = 1'b0;
         end else if (record_flag[5]) begin
-            #0.75ns;
+            #0.5ns;
             count_flag[5] = 8'd16;
             record_flag[5] = 1'b0;
         end else if (record_flag[6]) begin
-            #0.75ns;
+            #0.5ns;
             count_flag[6] = 8'd16;
             record_flag[6] = 1'b0;
         end else if (record_flag[7]) begin
-            #0.75ns;
+            #0.5ns;
             count_flag[7] = 8'd16;
             record_flag[7] = 1'b0;
         end

--- a/vlog/chip_src/tx_16t1/tx_top.sv
+++ b/vlog/chip_src/tx_16t1/tx_top.sv
@@ -186,8 +186,9 @@ qr_4t1_mux_top qr_mux_4t1_1 (
 );
 
 div_b2 div0 (.clkin(clk_interp_slice[2]), .rst(rst), .clkout(clk_halfrate));  // 4GHz to 2GHz, output goes to hr_16t4_mux
-div_b2 div1 (.clkin(clk_halfrate), .rst(rst), .clkout(clk_prbsgen));  // 2GHz to 1GHz, output goes to prbs_gen
-
+wire logic clk_halfrate_n;
+inv clk_inv(.in(clk_halfrate), .out(clk_halfrate_n));
+div_b2 div1 (.clkin(clk_halfrate_n), .rst(rst), .clkout(clk_prbsgen));  // 2GHz to 1GHz, output goes to prbs_gen
 
 // Instantiate the output buf
 output_buf_tx buf1 (

--- a/vlog/chip_src/tx_16t1/tx_top.sv
+++ b/vlog/chip_src/tx_16t1/tx_top.sv
@@ -26,6 +26,7 @@ module tx_top import const_pack::*; #(
 wire [3:0] qr_data_p;  // Output of 16 to 4 mux, positive
 wire [3:0] qr_data_n;  // Output of 16 to 4 mux, negative
 wire clk_halfrate;  // Input clock for 16 to 4 mux
+wire logic clk_halfrate_n;
 
 wire [3:0] clk_interp_slice; // Output from the phase interpolator
 wire [3:0] clk_interp_sw; //
@@ -186,7 +187,6 @@ qr_4t1_mux_top qr_mux_4t1_1 (
 );
 
 div_b2 div0 (.clkin(clk_interp_slice[2]), .rst(rst), .clkout(clk_halfrate));  // 4GHz to 2GHz, output goes to hr_16t4_mux
-wire logic clk_halfrate_n;
 inv clk_inv(.in(clk_halfrate), .out(clk_halfrate_n));
 div_b2 div1 (.clkin(clk_halfrate_n), .rst(rst), .clkout(clk_prbsgen));  // 2GHz to 1GHz, output goes to prbs_gen
 


### PR DESCRIPTION
Inverter added before 2GHz to 1GHz divider's input to fix the sampling timing.