### PR TITLE
cvxpy fix

### DIFF
--- a/mflowgen.sh
+++ b/mflowgen.sh
@@ -9,6 +9,9 @@ export PATH="$GENESIS_HOME/bin:$PATH"
 export PATH="$GENESIS_HOME/gui/bin:$PATH"
 /bin/rm -rf $GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions/Compress
 
+# temporary fix
+pip install cvxpy==1.1.7
+
 # install mflowgen
 git clone https://github.com/cornell-brg/mflowgen
 cd mflowgen

--- a/regress.sh
+++ b/regress.sh
@@ -18,6 +18,9 @@ export PATH="$GENESIS_HOME/gui/bin:$PATH"
 git clone --single-branch --branch pwl_cos https://github.com/StanfordVLSI/DaVE.git
 export mLINGUA_DIR=`realpath DaVE/mLingua`
 
+# temporary fix
+pip install cvxpy==1.1.7
+
 # install dragonphy
 pip install -e .
 


### PR DESCRIPTION
There is a problem installing the latest version of cvxpy (https://github.com/cvxgrp/cvxpy/issues/1229), so this pins the cvxpy version for the regression test to 1.1.7.